### PR TITLE
Some minor changes to the repo checks

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -130,12 +130,14 @@ def configure(args, parser):
             "doctr configure --force to run anyway.")
 
     build_repo = input("What repo do you want to build the docs for (org/reponame, like 'drdoctr/doctr')? ")
-    deploy_repo = input("What repo do you want to deploy the docs to? [{build_repo}] ".format(build_repo=build_repo))
+    check_repo_exists(build_repo)
 
+    deploy_repo = input("What repo do you want to deploy the docs to? [{build_repo}] ".format(build_repo=build_repo))
     if not deploy_repo:
         deploy_repo = build_repo
 
-    check_repo_exists(deploy_repo)
+    if deploy_repo != build_repo:
+        check_repo_exists(deploy_repo)
 
     N = IncrementingInt(1)
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -93,7 +93,10 @@ def process_args(parser):
         parser.print_usage()
         parser.exit(1)
 
-    return args.func(args, parser)
+    try:
+        return args.func(args, parser)
+    except RuntimeError as e:
+        sys.exit("Error: " + e.args[0])
 
 def on_travis():
     return os.environ.get("TRAVIS_JOB_NUMBER", '')

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -175,9 +175,14 @@ def generate_ssh_key(note, keypath='github_deploy_key'):
         return f.read()
 
 def check_repo_exists(deploy_repo):
-    """Checks that the deploy repository exists on GitHub before allowing
-    user to generate a key to deploy to that repo.
     """
+    Checks that the repository exists on GitHub.
+
+    This should be done before attempting generate a key to deploy to that repo.
+    """
+    if deploy_repo.count("/") != 1:
+        raise RuntimeError('"{deploy_repo}" should be in the form username/repo'.format(deploy_repo=deploy_repo))
+
     user, repo = deploy_repo.split('/')
     search = 'https://api.github.com/search/repositories?q={repo}+user:{user}'
     r = requests.get(search.format(user=user, repo=repo))

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -178,7 +178,10 @@ def check_repo_exists(deploy_repo):
     """
     Checks that the repository exists on GitHub.
 
-    This should be done before attempting generate a key to deploy to that repo.
+    This should be done before attempting generate a key to deploy to that
+    repo.
+
+    Raises ``RuntimeError`` if the repo is not valid.
     """
     if deploy_repo.count("/") != 1:
         raise RuntimeError('"{deploy_repo}" should be in the form username/repo'.format(deploy_repo=deploy_repo))

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -12,3 +12,10 @@ def test_bad_repo():
 
 def test_repo_exists():
     assert check_repo_exists('drdoctr/doctr')
+
+def test_invalid_repo():
+    with raises(RuntimeError):
+        check_repo_exists('fdsf')
+
+    with raises(RuntimeError):
+        check_repo_exists('fdsf/fdfs/fd')


### PR DESCRIPTION
- Check both the build and deploy repos
- Display RuntimeError errors without tracebacks
- Check that the repo is `org/repo` (otherwise you would get a ValueError)