### PR TITLE
Some refactoring of deploy functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
       make html;
       cd ..;
       python -m doctr deploy --gh-pages-docs . --key-path deploy_key.enc;
+      python -m doctr deploy --gh-pages-docs docs --key-path deploy_key.enc;
     fi
 
   - if [[ "${TESTS}" == "true" ]]; then

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,27 @@
  Doctr Changelog
 =================
 
+1.3 (????-??-??)
+================
+
+Major Changes
+-------------
+
+- Remove the ``--tmp-dir`` flag from the command line (doctr now always
+  deploys using a log file).
+- Python API: Change ``commit_docs`` to actually commit the docs (previously,
+  it was done in ``push_docs``).
+- Python API: Don't sync files or get the build dir in ``commit_docs``. This
+  is done separately in ``__main__.py``. The Python API for ``commit_docs`` is
+  now ``commit_docs(*, added, removed)``. ``sync_from_log`` automatically
+  includes the log file in the list of added files.
+
+Minor Changes
+-------------
+
+- Correctly commit the log file.
+- Fix sync_from_log to create dst if it doesn't exist, and add tests for this.
+
 1.2 (2016-08-29)
 ================
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -60,8 +60,8 @@ options available.
     deploy_parser.add_argument('--gh-pages-docs', default='docs',
         help="""Directory to deploy the html documentation to on gh-pages. The
         default is %(default)r.""")
-    deploy_parser.add_argument('--tmp-dir', default='_docs',
-        help="""Temporary directory used on gh-pages. The default is %(default)r.""")
+    deploy_parser.add_argument('--tmp-dir', default=None,
+        help=argparse.SUPPRESS)
     deploy_parser.add_argument('--deploy-repo', default=None, help="""Repo to
         deploy the docs to. By default, it deploys to the repo Doctr is run from.""")
     deploy_parser.add_argument('--no-require-master', dest='require_master', action='store_false',
@@ -106,6 +106,9 @@ def deploy(args, parser):
         parser.error("doctr does not appear to be running on Travis. Use "
             "doctr deploy --force to run anyway.")
 
+    if args.tmp_dir:
+        parser.error("The --tmp-dir flag has been removed (doctr no longer uses a temporary directory when deploying).")
+
     build_repo = get_current_repo()
     deploy_repo = args.deploy_repo or build_repo
 
@@ -113,7 +116,7 @@ def deploy(args, parser):
                          'deploy_key', full_key_path=args.key_path,
                          require_master=args.require_master):
         changes = commit_docs(built_docs=args.built_docs,
-            gh_pages_docs=args.gh_pages_docs, tmp_dir=args.tmp_dir)
+            gh_pages_docs=args.gh_pages_docs)
         if changes:
             push_docs()
         else:

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -112,9 +112,12 @@ def deploy(args, parser):
     if setup_GitHub_push(deploy_repo, auth_type='token' if args.token else
                          'deploy_key', full_key_path=args.key_path,
                          require_master=args.require_master):
-        commit_docs(built_docs=args.built_docs,
+        changes = commit_docs(built_docs=args.built_docs,
             gh_pages_docs=args.gh_pages_docs, tmp_dir=args.tmp_dir)
-        push_docs()
+        if changes:
+            push_docs()
+        else:
+            print("The docs have not changed. Not updating")
 
 class IncrementingInt:
     def __init__(self, i=0):

--- a/doctr/tests/test_travis.py
+++ b/doctr/tests/test_travis.py
@@ -35,6 +35,7 @@ def test_sync_from_log(src, dst):
             assert added == [
                 join(dst, 'test1'),
                 join(dst, 'testdir', 'test2'),
+                'logfile',
                 ]
 
             assert removed == []
@@ -61,6 +62,7 @@ def test_sync_from_log(src, dst):
                 join(dst, 'test1'),
                 join(dst, 'test3'),
                 join(dst, 'testdir', 'test2'),
+                'logfile',
             ]
 
             assert removed == []
@@ -89,6 +91,7 @@ def test_sync_from_log(src, dst):
             assert added == [
                 join(dst, 'test1'),
                 join(dst, 'testdir', 'test2'),
+                'logfile',
             ]
 
             assert removed == [
@@ -118,6 +121,7 @@ def test_sync_from_log(src, dst):
             assert added == [
                 join(dst, 'test1'),
                 join(dst, 'testdir', 'test2'),
+                'logfile',
             ]
 
             assert removed == []

--- a/doctr/tests/test_travis.py
+++ b/doctr/tests/test_travis.py
@@ -7,129 +7,133 @@ import tempfile
 import os
 from os.path import join
 
+import pytest
+
 from ..travis import sync_from_log
 
-def test_sync_from_log():
+@pytest.mark.parametrize("src", ["src"])
+@pytest.mark.parametrize("dst", ['.', 'dst'])
+def test_sync_from_log(src, dst):
     with tempfile.TemporaryDirectory() as dir:
         try:
             old_curdir = os.path.abspath(os.curdir)
             os.chdir(dir)
 
             # Set up a src directory with some files
-            os.makedirs('src')
+            os.makedirs(src)
 
-            with open(join('src', 'test1'), 'w') as f:
+            with open(join(src, 'test1'), 'w') as f:
                 f.write('test1')
 
-            os.makedirs(join('src', 'testdir'))
-            with open(join('src', 'testdir', 'test2'), 'w') as f:
+            os.makedirs(join(src, 'testdir'))
+            with open(join(src, 'testdir', 'test2'), 'w') as f:
                 f.write('test2')
 
             # Test that the sync happens
-            added, removed = sync_from_log('src', '.', 'logfile')
+            added, removed = sync_from_log(src, dst, 'logfile')
 
             assert added == [
-                join('.', 'test1'),
-                join('.', 'testdir', 'test2'),
+                join(dst, 'test1'),
+                join(dst, 'testdir', 'test2'),
                 ]
 
             assert removed == []
 
-            with open('test1') as f:
+            with open(join(dst, 'test1')) as f:
                 assert f.read() == 'test1'
 
-            with open(join('testdir', 'test2')) as f:
+            with open(join(dst, 'testdir', 'test2')) as f:
                 assert f.read() == 'test2'
 
             with open('logfile') as f:
                 assert f.read() == '\n'.join([
-                    join('.', 'test1'),
-                    join('.', 'testdir', 'test2'),
+                    join(dst, 'test1'),
+                    join(dst, 'testdir', 'test2'),
                     ])
 
             # Create a new file
-            with open(join('src', 'test3'), 'w') as f:
+            with open(join(src, 'test3'), 'w') as f:
                 f.write('test3')
 
-            added, removed = sync_from_log('src', '.', 'logfile')
+            added, removed = sync_from_log(src, dst, 'logfile')
 
             assert added == [
-                join('.', 'test1'),
-                join('.', 'test3'),
-                join('.', 'testdir', 'test2'),
+                join(dst, 'test1'),
+                join(dst, 'test3'),
+                join(dst, 'testdir', 'test2'),
             ]
 
             assert removed == []
 
-            with open('test1') as f:
+            with open(join(dst, 'test1')) as f:
                 assert f.read() == 'test1'
 
-            with open(join('testdir', 'test2')) as f:
+            with open(join(dst, 'testdir', 'test2')) as f:
                 assert f.read() == 'test2'
 
-            with open('test3') as f:
+            with open(join(dst, 'test3')) as f:
                 assert f.read() == 'test3'
 
             with open('logfile') as f:
                 assert f.read() == '\n'.join([
-                    join('.', 'test1'),
-                    join('.', 'test3'),
-                    join('.', 'testdir', 'test2'),
+                    join(dst, 'test1'),
+                    join(dst, 'test3'),
+                    join(dst, 'testdir', 'test2'),
                     ])
 
             # Delete a file
-            os.remove(join('src', 'test3'))
+            os.remove(join(src, 'test3'))
 
-            added, removed = sync_from_log('src', '.', 'logfile')
+            added, removed = sync_from_log(src, dst, 'logfile')
 
             assert added == [
-                join('.', 'test1'),
-                join('.', 'testdir', 'test2'),
+                join(dst, 'test1'),
+                join(dst, 'testdir', 'test2'),
             ]
 
             assert removed == [
-                join('.', 'test3'),
+                join(dst, 'test3'),
             ]
 
-            with open('test1') as f:
+            with open(join(dst, 'test1')) as f:
                 assert f.read() == 'test1'
 
-            with open(join('testdir', 'test2')) as f:
+            with open(join(dst, 'testdir', 'test2')) as f:
                 assert f.read() == 'test2'
 
-            assert not os.path.exists('test3')
+            assert not os.path.exists(join(dst, 'test3'))
 
             with open('logfile') as f:
                 assert f.read() == '\n'.join([
-                    join('.', 'test1'),
-                    join('.', 'testdir', 'test2'),
+                    join(dst, 'test1'),
+                    join(dst, 'testdir', 'test2'),
                     ])
 
             # Change a file
-            with open(join('src', 'test1'), 'w') as f:
+            with open(join(src, 'test1'), 'w') as f:
                 f.write('test1 modified')
 
-            added, removed = sync_from_log('src', '.', 'logfile')
+            added, removed = sync_from_log(src, dst, 'logfile')
 
             assert added == [
-                join('.', 'test1'),
-                join('.', 'testdir', 'test2'),
+                join(dst, 'test1'),
+                join(dst, 'testdir', 'test2'),
             ]
 
             assert removed == []
 
-            with open('test1') as f:
+            with open(join(dst, 'test1')) as f:
                 assert f.read() == 'test1 modified'
 
-            with open(join('testdir', 'test2')) as f:
+            with open(join(dst, 'testdir', 'test2')) as f:
                 assert f.read() == 'test2'
 
-            assert not os.path.exists('test3')
+            assert not os.path.exists(join(dst, 'test3'))
 
             with open('logfile') as f:
                 assert f.read() == '\n'.join([
-                    join('.', 'test1'),
-                    join('.', 'testdir', 'test2'),
+                    join(dst, 'test1'),
+                    join(dst, 'testdir', 'test2'),
                     ])
 
         finally:

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -258,7 +258,7 @@ def sync_from_log(src, dst, log_file):
     Returns ``(added, removed)``, where added is a list of all files synced from
     ``src`` (even if it already existed in ``dst``), and ``removed`` is every
     file from ``log_file`` that was removed from ``dst`` because it wasn't in
-    ``src``.
+    ``src``. ``added`` also includes the log file.
     """
     from os.path import join, exists, isdir
     if not src.endswith(os.sep):
@@ -296,9 +296,11 @@ def sync_from_log(src, dst, log_file):
     with open(log_file, 'w') as f:
         f.write('\n'.join(added))
 
+    added.append(log_file)
+
     return added, removed
 
-def commit_docs(*, built_docs=None, gh_pages_docs='docs', log_file='.doctr-files'):
+def commit_docs(*, added, removed):
     """
     Commit the docs to ``gh-pages``
 
@@ -310,16 +312,10 @@ def commit_docs(*, built_docs=None, gh_pages_docs='docs', log_file='.doctr-files
     """
     TRAVIS_BUILD_NUMBER = os.environ.get("TRAVIS_BUILD_NUMBER", "<unknown>")
 
-    if not built_docs:
-        built_docs = find_sphinx_build_dir()
-    print("Moving built docs into place")
-    added, removed = sync_from_log(src=built_docs, dst=gh_pages_docs,
-        log_file=log_file)
     for f in added:
         run(['git', 'add', f])
     for f in removed:
         run(['git', 'rm', f])
-    run(['git', 'add', log_file])
 
     # Only commit if there were changes
     if subprocess.run(['git', 'diff-index', '--quiet', 'HEAD', '--'],

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -300,7 +300,7 @@ def sync_from_log(src, dst, log_file):
 
     return added, removed
 
-def commit_docs(*, built_docs=None, gh_pages_docs='docs', tmp_dir='_docs', log_file='.doctr-files'):
+def commit_docs(*, built_docs=None, gh_pages_docs='docs', log_file='.doctr-files'):
     """
     Commit the docs to ``gh-pages``
 
@@ -315,21 +315,13 @@ def commit_docs(*, built_docs=None, gh_pages_docs='docs', tmp_dir='_docs', log_f
     if not built_docs:
         built_docs = find_sphinx_build_dir()
     print("Moving built docs into place")
-    if gh_pages_docs == '.':
-        added, removed = sync_from_log(src=built_docs, dst=gh_pages_docs,
-            log_file=log_file)
-        for f in added:
-            run(['git', 'add', f])
-        for f in removed:
-            run(['git', 'rm', f])
-        run(['git', 'add', log_file])
-    else:
-        shutil.copytree(built_docs, tmp_dir)
-        if os.path.exists(gh_pages_docs):
-            # Won't exist on the first build
-            shutil.rmtree(gh_pages_docs)
-        os.rename(tmp_dir, gh_pages_docs)
-        run(['git', 'add', '-A', gh_pages_docs])
+    added, removed = sync_from_log(src=built_docs, dst=gh_pages_docs,
+        log_file=log_file)
+    for f in added:
+        run(['git', 'add', f])
+    for f in removed:
+        run(['git', 'rm', f])
+    run(['git', 'add', log_file])
 
     # Only commit if there were changes
     if subprocess.run(['git', 'diff-index', '--quiet', 'HEAD', '--'],

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -284,8 +284,6 @@ def sync_from_log(src, dst, log_file):
     files = glob.iglob(join(src, '**'), recursive=True)
     # sorted makes this easier to test
     for f in sorted(files):
-        if f == src:
-            continue
         new_f = join(dst, f[len(src):])
         if isdir(f):
             os.makedirs(new_f, exist_ok=True)

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -318,6 +318,7 @@ def commit_docs(*, built_docs=None, gh_pages_docs='docs', tmp_dir='_docs', log_f
             run(['git', 'add', f])
         for f in removed:
             run(['git', 'rm', f])
+        run(['git', 'add', log_file])
     else:
         shutil.copytree(built_docs, tmp_dir)
         if os.path.exists(gh_pages_docs):


### PR DESCRIPTION
This breaks the Python API in several ways and the command line API in one minor way (an old option that was never used has been removed).

- Bugfix: commit the log file.
- Change `commit_docs` to actually commit the docs (previously, it was done in `push_docs`).
- Remove the `--tmp-dir` flag from the command line (always deploy using a log file).
- Fix `sync_from_log` to create dst if it doesn't exist, and add tests for this. 
- Don't sync files or get the build dir in `commit_docs`. This is done separately in `__main__.py`. The Python API for `commit_docs` is now `commit_docs(*, added, removed)`. 
- `sync_from_log` automatically includes the log file in the list of `added` files. 

This paves the way to fix https://github.com/drdoctr/doctr/issues/91. I want to merge this first and make sure nothing is broken first, though. 