### PR TITLE
Don't use doctr.run to checkout the original commit

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -151,7 +151,7 @@ def deploy(args, parser):
             else:
                 print("The docs have not changed. Not updating")
     finally:
-        run(['git', 'checkout', current_commit])
+        subprocess.run(['git', 'checkout', current_commit])
 
 class IncrementingInt:
     def __init__(self, i=0):


### PR DESCRIPTION
It may be running from a fork, in which case, doctr will fail, because run
looks for the token.