### PR TITLE
Authentication for GH tests

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents:
    api
    changelog
    releasing
+   tests
 
 Indices and tables
 ==================

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -20,4 +20,4 @@ You can add the updated token to Travis on the `doctr Travis Settings Page
 
 Paste the token string into the ``Value`` field and ``TESTING_TOKEN`` in the
 ``Name`` field (unless you have changed this value in
-``doctr/tests/test_local.py``
+``doctr/tests/test_local.py``).

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -1,0 +1,23 @@
+GitHub Test Authentication
+--------------------------
+
+Many of the ``doctr`` tests in ``doctr/tests/test_local.py`` contact GitHub to
+check that invalid repo names raise errors, etc. However, the GitHub API has a
+hard limit of 60 requests / hour for unauthenticated requests and it is very
+easy to run over this when pushing many changes.
+
+In order to avoid this limit, there is a GitHub Personal Access Token stored in
+the ``doctr`` Travis account that is available as the environment variable
+``$TESTING_TOKEN``.
+
+To regenerate / change this token, first go to `GitHub Settings
+<https://github.com/settings/tokens>`_ and create a Personal Access Token. Make
+sure that all of the checkboxes are unchecked (this token should only have
+privileges to check in with the GitHub API).
+
+You can add the updated token to Travis on the `doctr Travis Settings Page
+<https://travis-ci.org/drdoctr/doctr/settings>`_.
+
+Paste the token string into the ``Value`` field and ``TESTING_TOKEN`` in the
+``Name`` field (unless you have changed this value in
+``doctr/tests/test_local.py``

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -4,22 +4,24 @@ from ..local import check_repo_exists
 
 from pytest import raises
 
-TEST_AUTH = os.environ.get('TESTING_TOKEN')
+TEST_TOKEN = os.environ.get('TESTING_TOKEN')
+HEADERS = {'Authorization': 'token {}'.format(TEST_TOKEN)}
+
 
 def test_bad_user():
     with raises(RuntimeError):
-        check_repo_exists('---/invaliduser', auth=TEST_AUTH)
+        check_repo_exists('---/invaliduser', headers=HEADERS)
 
 def test_bad_repo():
     with raises(RuntimeError):
-        check_repo_exists('drdoctr/---', auth=TEST_AUTH)
+        check_repo_exists('drdoctr/---', headers=HEADERS)
 
 def test_repo_exists():
-    assert not check_repo_exists('drdoctr/doctr', auth=TEST_AUTH)
+    assert not check_repo_exists('drdoctr/doctr', headers=HEADERS)
 
 def test_invalid_repo():
     with raises(RuntimeError):
-        check_repo_exists('fdsf', auth=TEST_AUTH)
+        check_repo_exists('fdsf', headers=HEADERS)
 
     with raises(RuntimeError):
-        check_repo_exists('fdsf/fdfs/fd', auth=TEST_AUTH)
+        check_repo_exists('fdsf/fdfs/fd', headers=HEADERS)

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -4,8 +4,11 @@ from ..local import check_repo_exists
 
 from pytest import raises
 
-TEST_TOKEN = os.environ.get('TESTING_TOKEN')
-HEADERS = {'Authorization': 'token {}'.format(TEST_TOKEN)}
+TEST_TOKEN = os.environ.get('TESTING_TOKEN', None)
+if TEST_TOKEN:
+    HEADERS = {'Authorization': 'token {}'.format(TEST_TOKEN)}
+else:
+    HEADERS = None
 
 
 def test_bad_user():

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -1,21 +1,25 @@
+import os
+
 from ..local import check_repo_exists
 
 from pytest import raises
 
+TEST_AUTH = os.environ.get('TESTING_TOKEN')
+
 def test_bad_user():
     with raises(RuntimeError):
-        check_repo_exists('---/invaliduser')
+        check_repo_exists('---/invaliduser', auth=TEST_AUTH)
 
 def test_bad_repo():
     with raises(RuntimeError):
-        check_repo_exists('drdoctr/---')
+        check_repo_exists('drdoctr/---', auth=TEST_AUTH)
 
 def test_repo_exists():
-    assert not check_repo_exists('drdoctr/doctr')
+    assert not check_repo_exists('drdoctr/doctr', auth=TEST_AUTH)
 
 def test_invalid_repo():
     with raises(RuntimeError):
-        check_repo_exists('fdsf')
+        check_repo_exists('fdsf', auth=TEST_AUTH)
 
     with raises(RuntimeError):
-        check_repo_exists('fdsf/fdfs/fd')
+        check_repo_exists('fdsf/fdfs/fd', auth=TEST_AUTH)


### PR DESCRIPTION
I created a personal access token for GitHub that has no permissions and added it to the doctr travis org so it can be used to authenticate requests to GH for the tests.  This changes the rate limiting from 60/hour to 5000/hour and so should eliminate the annoying test failures we've had to deal with.