### PR TITLE
Add more information to the automated commit message

### DIFF
--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -338,13 +338,15 @@ def commit_docs(*, added, removed):
 Update docs after building Travis build {TRAVIS_BUILD_NUMBER} of
 {TRAVIS_REPO_SLUG}
 
-The docs were built from the branch {TRAVIS_BRANCH} against commit
+The docs were built from the branch '{TRAVIS_BRANCH}' against the commit
 {TRAVIS_COMMIT}.
 
 The Travis build that generated this commit is at
 https://travis-ci.org/{TRAVIS_REPO_SLUG}/jobs/{TRAVIS_JOB_ID}.
 
-The doctr command that was run is {DOCTR_COMMAND}.
+The doctr command that was run is
+
+    {DOCTR_COMMAND}
 """.format(
     TRAVIS_BUILD_NUMBER=TRAVIS_BUILD_NUMBER,
     TRAVIS_BRANCH=TRAVIS_BRANCH,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -323,17 +323,31 @@ def commit_docs(*, added, removed):
     committed.
     """
     TRAVIS_BUILD_NUMBER = os.environ.get("TRAVIS_BUILD_NUMBER", "<unknown>")
+    TRAVIS_BRANCH = os.environ.get("TRAVIS_BRANCH", "<unknown>")
+    TRAVIS_COMMIT = os.environ.get("TRAVIS_COMMIT", "<unknown>")
+    TRAVIS_REPO_SLUG = os.environ.get("TRAVIS_REPO_SLUG", "<unknown>")
 
     for f in added:
         run(['git', 'add', f])
     for f in removed:
         run(['git', 'rm', f])
 
+    commit_message = """\
+Update docs after building Travis build {TRAVIS_BUILD_NUMBER} of {TRAVIS_REPO_SLUG}
+
+The docs were built from the branch {TRAVIS_BRANCH} against commit {TRAVIS_COMMIT}.
+""".format(
+    TRAVIS_BUILD_NUMBER=TRAVIS_BUILD_NUMBER,
+    TRAVIS_BRANCH=TRAVIS_BRANCH,
+    TRAVIS_COMMIT=TRAVIS_COMMIT,
+    TRAVIS_REPO_SLUG=TRAVIS_REPO_SLUG,
+    )
+
     # Only commit if there were changes
     if subprocess.run(['git', 'diff-index', '--quiet', 'HEAD', '--'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE).returncode != 0:
         print("Committing")
-        run(['git', 'commit', '-am', "Update docs after building Travis build " + TRAVIS_BUILD_NUMBER])
+        run(['git', 'commit', '-am', commit_message])
         return True
 
     return False

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -326,6 +326,8 @@ def commit_docs(*, added, removed):
     TRAVIS_BRANCH = os.environ.get("TRAVIS_BRANCH", "<unknown>")
     TRAVIS_COMMIT = os.environ.get("TRAVIS_COMMIT", "<unknown>")
     TRAVIS_REPO_SLUG = os.environ.get("TRAVIS_REPO_SLUG", "<unknown>")
+    TRAVIS_JOB_ID = os.environ.get("TRAVIS_JOB_ID", "")
+    DOCTR_COMMAND = ' '.join(map(shlex.quote, sys.argv))
 
     for f in added:
         run(['git', 'add', f])
@@ -333,14 +335,23 @@ def commit_docs(*, added, removed):
         run(['git', 'rm', f])
 
     commit_message = """\
-Update docs after building Travis build {TRAVIS_BUILD_NUMBER} of {TRAVIS_REPO_SLUG}
+Update docs after building Travis build {TRAVIS_BUILD_NUMBER} of
+{TRAVIS_REPO_SLUG}
 
-The docs were built from the branch {TRAVIS_BRANCH} against commit {TRAVIS_COMMIT}.
+The docs were built from the branch {TRAVIS_BRANCH} against commit
+{TRAVIS_COMMIT}.
+
+The Travis build that generated this commit is at
+https://travis-ci.org/{TRAVIS_REPO_SLUG}/jobs/{TRAVIS_JOB_ID}.
+
+The doctr command that was run is {DOCTR_COMMAND}.
 """.format(
     TRAVIS_BUILD_NUMBER=TRAVIS_BUILD_NUMBER,
     TRAVIS_BRANCH=TRAVIS_BRANCH,
     TRAVIS_COMMIT=TRAVIS_COMMIT,
     TRAVIS_REPO_SLUG=TRAVIS_REPO_SLUG,
+    TRAVIS_JOB_ID=TRAVIS_JOB_ID,
+    DOCTR_COMMAND=DOCTR_COMMAND,
     )
 
     # Only commit if there were changes


### PR DESCRIPTION
It now includes the repo name, branch, and commit.

We could add other things, but that would require passing in information to
commit_docs().

For reference, the list of all environment variables in Travis is at
https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables.

Fixes https://github.com/drdoctr/doctr/issues/105 (although I might want to include more info than this). 