### PR TITLE
check if travis returns a PNG instead of json

### DIFF
--- a/doctr/local.py
+++ b/doctr/local.py
@@ -236,7 +236,8 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
 
     r = requests.get(REPO_URL.format(user=user, repo=repo), auth=auth, headers=headers)
 
-    if r.status_code == requests.codes.not_found:
+    if (r.status_code == requests.codes.not_found or
+        'PNG'.encode('UTF-8') in r.content):
         raise RuntimeError('"{user}/{repo}" not found on {service}. Exiting'.format(user=user,
                                                                                     repo=repo,
                                                                                     service=service))


### PR DESCRIPTION
Travis has changed how they respond to requests for invalid repos --
returning a PNG badge instead of JSON which makes `json` very sad. While
it's kind of ridiculous, the `check_repo_exists` function now checks to
see if `PNG` is in the content of the request and raises a
`RuntimeError` if so.

I think it's safe to assume that if a PNG has been returned in response
to this call that clearly SOMETHING has gone wrong.