### PR TITLE
add warning about needing `set -e` in travis.yml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,11 @@ in your ``.travis.yml``. See `the one
 <https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
 itself for example.
 
-**Warning: ** To stop a Travis build when the docs fail to build, you must add
- ``set -e`` in ``script``.
+**Warning:** To stop a Travis build when the docs fail to build, you must add
+ ``set -e`` in ``script``. If you put ``doctr deploy`` in ``after_success``
+ instead of ``script``, it will `not cause
+ <https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
+ the build to fail.
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ something like
        secure: "<your secure key from doctr here>"
 
    script:
+     - set -e
      - pip install sphinx doctr
      - cd docs
      - make html
@@ -65,10 +66,12 @@ something like
 
 in your ``.travis.yml``. See `the one
 <https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
-itself for example. Warning, if you put ``doctr deploy`` in ``after_success``
-instead of ``script``, it will `not cause
-<https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
-the build to fail if it fails.
+itself for example.
+
+**Warning: ** To stop a Travis build when the docs fail to build, you must add
+ ``set -e`` in ``script``.
+
+
 
 **Heads up:** Doctr requires Python 3.5 or newer. Be sure to run it in a
 Python 3.5 or newer section of your build matrix. It should be in the same

--- a/README.rst
+++ b/README.rst
@@ -68,11 +68,17 @@ in your ``.travis.yml``. See `the one
 <https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
 itself for example.
 
-**Warning:** To stop a Travis build when the docs fail to build, you must add
- ``set -e`` in ``script``. If you put ``doctr deploy`` in ``after_success``
- instead of ``script``, it will `not cause
- <https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
- the build to fail.
+.. warning::
+
+   Be sure to add ``set -e`` in ``script``, to prevent ``doctr`` from running
+   when the docs build fails.
+
+.. warning::
+
+   Put ``doctr deploy`` in the ``script`` section of your ``.travis.yml``. If
+   you use ``after_success``, it will `not cause
+   <https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
+   the build to fail.
 
 
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -250,10 +250,15 @@ def configure(args, parser):
     print(dedent("""\
     {N}. Add
 
-        - pip install doctr
-        - doctr deploy{options}
+        script:
+          - set -e
+          - # Command to build your docs
+          - pip install doctr
+          - doctr deploy{options}
 
-    to the docs build of your .travis.yml.
+    to the docs build of your .travis.yml.  The 'set -e' prevents doctr from
+    running when the docs build fails. Use the 'script' section so that if
+    doctr fails it causes the build to fail.
     """.format(options=options, N=N)))
 
     print(dedent("""\

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -81,7 +81,7 @@ options available.
     deploy_parser.add_argument('--no-push', dest='push', action='store_false',
         default=True, help="Run all the steps except the last push step."
         "Useful for debugging")
-        
+
 
     configure_parser = subcommand.add_parser('configure', help="Configure doctr. This command should be run locally (not on Travis).")
     configure_parser.set_defaults(func=configure)


### PR DESCRIPTION
as mentioned in #144.  we were already using `set -e` in doctr's `travis.yml` so that doesn't need any updates.