### PR TITLE
specify that git pull should grab doctr_remote

### DIFF
--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -379,6 +379,6 @@ def push_docs():
     """
 
     print("Pulling")
-    run(["git", "pull"])
+    run(['git', 'pull', 'doctr_remote', 'gh-pages'])
     print("Pushing commit")
     run(['git', 'push', '-q', 'doctr_remote', 'gh-pages'])


### PR DESCRIPTION
as discussed in https://github.com/xonsh/xonsh/pull/2039#issuecomment-269878414 
specifies an explicit pull target to avoid grabbing the wrong branch (or even the wrong repo...) still not sure how this happens in the first place but I think this might fix it.