### PR TITLE
Delete the public key automatically

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -233,12 +233,9 @@ def configure(args, parser):
             Be sure to allow write access for the key.
             """.format(ssh_key=ssh_key, deploy_keys_url=deploy_keys_url, N=N)))
 
-        # TODO: Should we just delete the public key?
 
         print(dedent("""\
         {N}. Commit the file {keypath}.enc.
-        The file {keypath}.pub contains the public deploy key for GitHub. It
-        does not need to be committed.
         """.format(keypath=args.key_path, N=N)))
 
     options = ''

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -210,7 +210,11 @@ def generate_ssh_key(note, keypath='github_deploy_key'):
         raise RuntimeError("SSH key generation failed")
 
     with open(keypath + ".pub") as f:
-        return f.read()
+        key = f.read()
+
+    os.remove(keypath + ".pub")
+
+    return key
 
 def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None):
     """


### PR DESCRIPTION
There is no need to keep it around, and it just confuses people. If the public
key is needed again, the best thing to do is to just run doctr configure
again to generate a new set of keys.

Fixes #112. 