### PR TITLE
Set Travis language to generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: generic
 
 sudo: false
 env:


### PR DESCRIPTION
We don't need Python since we are using Miniconda and this should hopefully be
faster.