### PR TITLE
make deploy directory required argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
       python -m doctr deploy --key-path deploy_key.enc .;
       python -m doctr deploy --key-path deploy_key.enc --gh-pages-docs docs;
       python -m doctr deploy --no-require-master  --built-docs docs/_build/html --key-path deploy_key.enc "docs-$TRAVIS_BRANCH";
-      python -m doctr deploy --no-require-master --key-path deploy_key.enc --no-sync --command "echo test";
+      python -m doctr deploy --no-require-master --key-path deploy_key.enc --no-sync --command "echo test" docs;
     fi
   - if [[ "${TESTS}" == "true" ]]; then
       pyflakes doctr;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
       make html;
       cd ..;
       python -m doctr deploy --key-path deploy_key.enc .;
-      python -m doctr deploy --key-path deploy_key.enc docs;
+      python -m doctr deploy --key-path deploy_key.enc --gh-pages-docs docs;
       python -m doctr deploy --no-require-master  --built-docs docs/_build/html --key-path deploy_key.enc "docs-$TRAVIS_BRANCH";
       python -m doctr deploy --no-require-master --key-path deploy_key.enc --no-sync --command "echo test";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ script:
       cd docs;
       make html;
       cd ..;
-      python -m doctr deploy --gh-pages-docs . --key-path deploy_key.enc;
-      python -m doctr deploy --gh-pages-docs docs --key-path deploy_key.enc;
-      python -m doctr deploy --no-require-master --gh-pages-docs "docs-$TRAVIS_BRANCH" --built-docs docs/_build/html --key-path deploy_key.enc;
+      python -m doctr deploy --key-path deploy_key.enc .;
+      python -m doctr deploy --key-path deploy_key.enc docs;
+      python -m doctr deploy --no-require-master  --built-docs docs/_build/html --key-path deploy_key.enc "docs-$TRAVIS_BRANCH";
       python -m doctr deploy --no-require-master --key-path deploy_key.enc --no-sync --command "echo test";
     fi
   - if [[ "${TESTS}" == "true" ]]; then

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,9 @@
 
 Current
 =======
-- There is no longer a default deploy directory. Specify the deploy directory 
-  like ``doctr deploy .`` or ``doctr deploy docs``. (:issue:`128`)
+- The ``--gh-pages-docs`` flag of ``doctr deploy`` has been deprecated.
+  Specify the deploy directory like ``doctr deploy .`` or ``doctr deploy docs``.
+  There is also no longer a default deploy directory. (:issue:`128`)
 
 
 1.4.1 (2017-01-11)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,8 @@
 
 Current
 =======
-- Change deploy directory to required argument. This is a backwards incompatible change. Default deploy without arguments should now read ``doctr deploy .`` (:issue:`128`)
+- There is no longer a default deploy directory. Specify the deploy directory 
+  like ``doctr deploy .`` or ``doctr deploy docs``. (:issue:`128`)
 
 
 1.4.1 (2017-01-11)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
  Doctr Changelog
 =================
 
+Current
+=======
+- Change deploy directory to required argument. This is a backwards incompatible change. Default deploy without arguments should now read ``doctr deploy .`` (:issue:`128`)
+
+
 1.4.1 (2017-01-11)
 ==================
 - Fix Travis API endpoint when checking if a repo exists. (:issue:`143`)

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -81,8 +81,10 @@ options available.
         default=True, help="Run all the steps except the last push step."
         "Useful for debugging")
     deploy_parser.add_argument('--gh-pages-docs', default='docs',
-        help="""!!DEPRECATED!! Directory to deploy the html documentation to on gh-pages. The
-        default is %(default)r.""")
+        help="""!!DEPRECATED!! Directory to deploy the html documentation to on gh-pages.
+        The default is %(default)r. The deploy directory should be passed as
+        the first argument to 'doctr deploy'. This flag is kept for backwards
+        compatibility.""")
 
 
     configure_parser = subcommand.add_parser('configure', help="Configure doctr. This command should be run locally (not on Travis).")

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -80,7 +80,7 @@ options available.
     deploy_parser.add_argument('--no-push', dest='push', action='store_false',
         default=True, help="Run all the steps except the last push step."
         "Useful for debugging")
-    deploy_parser.add_argument('--gh-pages-docs', default='docs',
+    deploy_parser.add_argument('--gh-pages-docs', default=None,
         help="""!!DEPRECATED!! Directory to deploy the html documentation to on gh-pages.
         The default is %(default)r. The deploy directory should be passed as
         the first argument to 'doctr deploy'. This flag is kept for backwards
@@ -129,6 +129,17 @@ def deploy(args, parser):
     if args.tmp_dir:
         parser.error("The --tmp-dir flag has been removed (doctr no longer uses a temporary directory when deploying).")
 
+    if args.gh_pages_docs:
+        print("The --gh-pages-docs flag is deprecated and will be removed in the next release. Instead pass the deploy directory as an argument, e.g. `doctr deploy .`")
+
+    if args.gh_pages_docs and args.deploy_directory:
+        parser.error("The --gh-pages-docs flag is deprecated. Specify the directory to deploy to using `doctr deploy <dir>`")
+
+    if not args.gh_pages_docs and not args.deploy_directory:
+        parser.error("No deploy directory specified. Specify the directory to deploy to using `doctr deploy <dir>`")
+
+    deploy_dir = args.gh_pages_docs or args.deploy_directory
+
     build_repo = get_current_repo()
     deploy_repo = args.deploy_repo or build_repo
 
@@ -141,11 +152,11 @@ def deploy(args, parser):
         if args.sync:
             built_docs = args.built_docs or find_sphinx_build_dir()
 
-            log_file = os.path.join(args.gh_pages_docs, '.doctr-files')
+            log_file = os.path.join(deploy_dir, '.doctr-files')
 
             print("Moving built docs into place")
             added, removed = sync_from_log(src=built_docs,
-                dst=args.gh_pages_docs, log_file=log_file)
+                dst=deploy_dir, log_file=log_file)
 
         else:
             added, removed = [], []

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -50,6 +50,8 @@ options available.
     subcommand = parser.add_subparsers(title='subcommand', dest='subcommand')
     deploy_parser = subcommand.add_parser('deploy', help="""Deploy the docs to GitHub from Travis.""")
     deploy_parser.set_defaults(func=deploy)
+    deploy_parser.add_argument('deploy_directory', type=str, nargs='?',
+        help="""Directory to deploy the html documentation to on gh-pages.""")
     deploy_parser.add_argument('--force', action='store_true', help="""Run the deploy command even
     if we do not appear to be on Travis.""")
     deploy_parser.add_argument('--token', action='store_true', default=False,
@@ -60,8 +62,6 @@ options available.
     deploy_parser.add_argument('--built-docs', default=None,
         help="""Location of the built html documentation to be deployed to
         gh-pages. If not specified, Doctr will try to automatically detect build location""")
-    deploy_parser.add_argument('deploy_directory', type=str,
-        help="""Directory to deploy the html documentation to on gh-pages.""")
     deploy_parser.add_argument('--tmp-dir', default=None,
         help=argparse.SUPPRESS)
     deploy_parser.add_argument('--deploy-repo', default=None, help="""Repo to
@@ -80,6 +80,9 @@ options available.
     deploy_parser.add_argument('--no-push', dest='push', action='store_false',
         default=True, help="Run all the steps except the last push step."
         "Useful for debugging")
+    deploy_parser.add_argument('--gh-pages-docs', default='docs',
+        help="""!!DEPRECATED!! Directory to deploy the html documentation to on gh-pages. The
+        default is %(default)r.""")
 
 
     configure_parser = subcommand.add_parser('configure', help="Configure doctr. This command should be run locally (not on Travis).")

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -60,9 +60,8 @@ options available.
     deploy_parser.add_argument('--built-docs', default=None,
         help="""Location of the built html documentation to be deployed to
         gh-pages. If not specified, Doctr will try to automatically detect build location""")
-    deploy_parser.add_argument('--gh-pages-docs', default='docs',
-        help="""Directory to deploy the html documentation to on gh-pages. The
-        default is %(default)r.""")
+    deploy_parser.add_argument('deploy_directory', type=str,
+        help="""Directory to deploy the html documentation to on gh-pages.""")
     deploy_parser.add_argument('--tmp-dir', default=None,
         help=argparse.SUPPRESS)
     deploy_parser.add_argument('--deploy-repo', default=None, help="""Repo to
@@ -251,7 +250,7 @@ def configure(args, parser):
           - set -e
           - # Command to build your docs
           - pip install doctr
-          - doctr deploy{options}
+          - doctr deploy{options} {deploy_directory}
 
     to the docs build of your .travis.yml.  The 'set -e' prevents doctr from
     running when the docs build fails. Use the 'script' section so that if


### PR DESCRIPTION
as per discussion in #128, changing the deploy directory to a required
argument. the new usage for doctr on the travis side of things would
be

```
doctr deploy .
```

to deploy to the root directory on the ``gh-pages`` branch.