### PR TITLE
Check root

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
  Doctr Changelog
 =================
 
+Current
+=======
+- Error/warn user if ``doctr configure`` is run not at root of git repo
+  (:issue:`162`)
+
 1.4.1 (2017-01-11)
 ==================
 - Fix Travis API endpoint when checking if a repo exists. (:issue:`143`)

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -30,7 +30,8 @@ import subprocess
 from textwrap import dedent
 
 from .local import (generate_GitHub_token, encrypt_variable, encrypt_file,
-    upload_GitHub_deploy_key, generate_ssh_key, check_repo_exists, GitHub_login)
+                    upload_GitHub_deploy_key, generate_ssh_key,
+                    check_repo_exists, GitHub_login, in_git_root)
 from .travis import (setup_GitHub_push, commit_docs, push_docs,
     get_current_repo, sync_from_log, find_sphinx_build_dir, run)
 from . import __version__
@@ -175,6 +176,11 @@ def configure(args, parser):
     if not args.force and on_travis():
         parser.error("doctr appears to be running on Travis. Use "
             "doctr configure --force to run anyway.")
+
+    if not args.force and not in_git_root():
+        parser.error("doctr should be run from the root directory "
+                     "of your repository. Use doctr configure --force "
+                     "to run anyway.")
 
     if args.upload_key:
         login_kwargs = GitHub_login()

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -248,3 +248,20 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
     r.raise_for_status()
 
     return r.json().get('private', False)
+
+def in_git_root():
+    """
+    Check if current working directory is root dir of git repo.
+    Return ``False`` if it isn't.
+    """
+    repo = subprocess.run(['git', 'rev-parse', '--show-toplevel'],
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if repo.returncode == 0:
+        root_dir = repo.stdout.decode('utf-8').strip()
+        if os.getcwd() == root_dir:
+            return True
+        else:
+            return False
+    else:
+        raise RuntimeError('doctr should be run in the root directory of a '
+                           'git repository')


### PR DESCRIPTION
If we are in a git repo but not at the root of it, print error and allow
user to ``--force`` doctr to run anyway.

If not in a git repo at all, raise a RuntimeError

Should address #162 