### PR TITLE
add command line argument deploy_branch_name that specifies a target …

### DIFF
--- a/doctr/__init__.py
+++ b/doctr/__init__.py
@@ -2,7 +2,7 @@ from .local import (encrypt_variable, encrypt_file, GitHub_post,
     generate_GitHub_token, upload_GitHub_deploy_key, generate_ssh_key,
     check_repo_exists)
 from .travis import (decrypt_file, setup_deploy_key, get_token, run,
-    setup_GitHub_push, gh_pages_exists, create_gh_pages, sync_from_log,
+    setup_GitHub_push, deploy_branch_exists, create_deploy_branch, sync_from_log,
     commit_docs, push_docs, get_current_repo, find_sphinx_build_dir)
 
 __all__ = [
@@ -10,8 +10,8 @@ __all__ = [
     'generate_GitHub_token', 'upload_GitHub_deploy_key', 'generate_ssh_key',
     'check_repo_exists',
 
-    'decrypt_file', 'setup_deploy_key', 'get_token', 'run', 'setup_GitHub_push', 'gh_pages_exists',
-    'create_gh_pages', 'sync_from_log', 'commit_docs', 'push_docs', 'get_current_repo', 'find_sphinx_build_dir'
+    'decrypt_file', 'setup_deploy_key', 'get_token', 'run', 'setup_GitHub_push', 'deploy_branch_exists',
+    'create_deploy_branch', 'sync_from_log', 'commit_docs', 'push_docs', 'get_current_repo', 'find_sphinx_build_dir'
 ]
 
 from ._version import get_versions

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -132,7 +132,7 @@ def get_current_repo():
     _, org, git_repo = remote_url.rsplit('.git', 1)[0].rsplit('/', 2)
     return (org + '/' + git_repo)
 
-def setup_GitHub_push(deploy_repo, deploy_branch='gh-pages', auth_type='deploy_key', full_key_path='github_deploy_key.enc', require_master=True):
+def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github_deploy_key.enc', require_master=True, deploy_branch='gh-pages'):
     """
     Setup the remote to push to GitHub (to be run on Travis).
 

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -197,7 +197,7 @@ def setup_GitHub_push(deploy_repo, deploy_branch='gh-pages', auth_type='deploy_k
 
     #create empty branch with .nojekyll if it doesn't already exist
     new_deploy_branch = create_deploy_branch(deploy_branch, push=canpush)
-    print("Checking out {}".format(deploy_branch)
+    print("Checking out {}".format(deploy_branch))
     local_deploy_branch_exists = deploy_branch in subprocess.check_output(['git', 'branch']).decode('utf-8').split()
     if new_deploy_branch or local_deploy_branch_exists:
         run(['git', 'checkout', deploy_branch])


### PR DESCRIPTION
…branch for the docs on the deploy_repo

addresses #86 

Hello! We were interested in being able to push to branches other than `gh-pages`. Specifically, we wanted to push docs to an organization page, but for some reason, Github pages requires that organization pages be on the `master` branch.

There wasn't a whole lot that needed to be changed, we just added a command line argument with the deploy branch name and rewrote some of the functions in which `gh-pages` was hard-coded.

Do you have any suggestions for how we can go about testing this PR? We are not entirely familiar with how you go about that, but let us know if there's anything else we can do.

cc: @eickenberg, @Carreau 