### PR TITLE
Deploy to any branch

### DIFF
--- a/doctr/__init__.py
+++ b/doctr/__init__.py
@@ -2,7 +2,7 @@ from .local import (encrypt_variable, encrypt_file, GitHub_post,
     generate_GitHub_token, upload_GitHub_deploy_key, generate_ssh_key,
     check_repo_exists)
 from .travis import (decrypt_file, setup_deploy_key, get_token, run,
-    setup_GitHub_push, gh_pages_exists, create_gh_pages, sync_from_log,
+    setup_GitHub_push, deploy_branch_exists, create_deploy_branch, sync_from_log,
     commit_docs, push_docs, get_current_repo, find_sphinx_build_dir)
 
 __all__ = [
@@ -10,8 +10,8 @@ __all__ = [
     'generate_GitHub_token', 'upload_GitHub_deploy_key', 'generate_ssh_key',
     'check_repo_exists',
 
-    'decrypt_file', 'setup_deploy_key', 'get_token', 'run', 'setup_GitHub_push', 'gh_pages_exists',
-    'create_gh_pages', 'sync_from_log', 'commit_docs', 'push_docs', 'get_current_repo', 'find_sphinx_build_dir'
+    'decrypt_file', 'setup_deploy_key', 'get_token', 'run', 'setup_GitHub_push', 'deploy_branch_exists',
+    'create_deploy_branch', 'sync_from_log', 'commit_docs', 'push_docs', 'get_current_repo', 'find_sphinx_build_dir'
 ]
 
 from ._version import get_versions

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -238,7 +238,7 @@ def deploy(args, parser):
     build_repo = get_current_repo()
     deploy_repo = args.deploy_repo or build_repo
 
-    deploy_branch = args.deploy_branch_name
+    deploy_branch = 'master' if deploy_dir.endswith('github.io') else args.deploy_branch_name
 
     current_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
     try:

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -136,7 +136,7 @@ options available.
         gh-pages. If not specified, Doctr will try to automatically detect build location""")
     deploy_parser.add_argument('--deploy-branch-name', default=None,
                                help="""Name of the branch to deploy to (default: 'master' for ``*.github.io``
-                               repos, 'gh-pages' otherwise""")
+                               repos, 'gh-pages' otherwise)""")
     deploy_parser_add_argument('--tmp-dir', default=None,
         help=argparse.SUPPRESS)
     deploy_parser_add_argument('--deploy-repo', default=None, help="""Repo to

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -135,7 +135,7 @@ options available.
         help="""Location of the built html documentation to be deployed to
         gh-pages. If not specified, Doctr will try to automatically detect build location""")
     deploy_parser.add_argument('--deploy-branch-name', default=None,
-                               help="""Name of the branch to deploy to (default: 'master' for *.github.io
+                               help="""Name of the branch to deploy to (default: 'master' for ``*.github.io``
                                repos, 'gh-pages' otherwise""")
     deploy_parser_add_argument('--tmp-dir', default=None,
         help=argparse.SUPPRESS)

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -134,8 +134,9 @@ options available.
     deploy_parser_add_argument('--built-docs', default=None,
         help="""Location of the built html documentation to be deployed to
         gh-pages. If not specified, Doctr will try to automatically detect build location""")
-    deploy_parser.add_argument('--deploy-branch-name', default='gh-pages',
-                               help="""Name of branch to deploy to""")
+    deploy_parser.add_argument('--deploy-branch-name', default=None,
+                               help="""Name of the branch to deploy to (default: 'master' for *.github.io
+                               repos, 'gh-pages' otherwise""")
     deploy_parser_add_argument('--tmp-dir', default=None,
         help=argparse.SUPPRESS)
     deploy_parser_add_argument('--deploy-repo', default=None, help="""Repo to
@@ -238,7 +239,10 @@ def deploy(args, parser):
     build_repo = get_current_repo()
     deploy_repo = args.deploy_repo or build_repo
 
-    deploy_branch = 'master' if deploy_dir.endswith('github.io') else args.deploy_branch_name
+    if args.deploy_branch_name:
+        deploy_branch = args.deploy_branch_name
+    else:
+        deploy_branch = 'master' if deploy_dir.endswith(('.github.io', '.github.com')) else 'gh-pages'
 
     current_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
     try:

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -132,7 +132,7 @@ def get_current_repo():
     _, org, git_repo = remote_url.rsplit('.git', 1)[0].rsplit('/', 2)
     return (org + '/' + git_repo)
 
-def setup_GitHub_push(deploy_repo, deploy_branch='gh-pages', auth_type='deploy_key', full_key_path='github_deploy_key.enc', require_master=True):
+def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github_deploy_key.enc', require_master=True, deploy_branch='gh-pages'):
     """
     Setup the remote to push to GitHub (to be run on Travis).
 

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -197,7 +197,7 @@ def setup_GitHub_push(deploy_repo, deploy_branch='gh-pages', auth_type='deploy_k
 
     #create empty branch with .nojekyll if it doesn't already exist
     new_deploy_branch = create_deploy_branch(deploy_branch, push=canpush)
-    print("Checking out {}".format(deploy_branch)
+    print("Checking out {}".format(deploy_branch))
     local_deploy_branch_exists = deploy_branch in subprocess.check_output(['git', 'branch']).decode('utf-8').split()
     if new_deploy_branch or local_deploy_branch_exists:
         run(['git', 'checkout', deploy_branch])

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -221,6 +221,7 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
 def deploy_branch_exists(deploy_branch):
     """
     Check if there is a remote branch with name specified in ``deploy_branch``.
+
     Note that default ``deploy_branch`` is ``gh-pages`` for regular repos and
     ``master`` for ``github.io`` repos.
 
@@ -236,6 +237,7 @@ def create_deploy_branch(deploy_branch, push=True):
     """
     If there is no remote branch with name specified in ``deploy_branch``,
     create one.
+
     Note that default ``deploy_branch`` is ``gh-pages`` for regular
     repos and ``master`` for ``github.io`` repos.
 

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -220,11 +220,12 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
 
 def deploy_branch_exists(deploy_branch):
     """
-    Check if there is a remote branch named ``deploy_branch``.
+    Check if there is a remote branch with name specified in ``deploy_branch``.
+    Note that default ``deploy_branch`` is ``gh-pages`` for regular repos and
+    ``master`` for ``github.io`` repos.
 
     This isn't completely robust. If there are multiple remotes and you have a
     ``deploy_branch`` branch on the non-default remote, this won't see it.
-
     """
     remote_name = 'doctr_remote'
     branch_names = subprocess.check_output(['git', 'branch', '-r']).decode('utf-8').split()
@@ -233,7 +234,10 @@ def deploy_branch_exists(deploy_branch):
 
 def create_deploy_branch(deploy_branch, push=True):
     """
-    If there is no remote branch named ``deploy_branch``, create one.
+    If there is no remote branch with name specified in ``deploy_branch``,
+    create one.
+    Note that default ``deploy_branch`` is ``gh-pages`` for regular
+    repos and ``master`` for ``github.io`` repos.
 
     Return True if ``deploy_branch`` was created, False if not.
     """


### PR DESCRIPTION
Additions to #164 -- updated against master and having it default to pushing to the `master` branch if the repo is a `github.io` repo.

@asmeurer - in re: using drdoctr.github.io did you want to stop pushing docs to the `doctr` repo entirely? I'm fine with that, but I think it has to be one or the other since we aren't allowed to use the same deploy key on two repos (i think)