### PR TITLE
only allow pushes from master or whitelisted branches

### DIFF
--- a/doctr/tests/test_travis.py
+++ b/doctr/tests/test_travis.py
@@ -9,7 +9,7 @@ from os.path import join
 
 import pytest
 
-from ..travis import sync_from_log
+from ..travis import sync_from_log, determine_push_rights
 
 @pytest.mark.parametrize("src", ["src"])
 @pytest.mark.parametrize("dst", ['.', 'dst'])
@@ -142,3 +142,20 @@ def test_sync_from_log(src, dst):
 
         finally:
             os.chdir(old_curdir)
+
+
+@pytest.mark.parametrize("travis_branch, travis_pr, whitelist, canpush",
+                         [('doctr', 'true', 'master', False),
+                          ('doctr', 'false', 'master', False),
+                          ('master', 'true', 'master', False),
+                          ('master', 'false', 'master', True),
+                          ('doctr', 'True', 'doctr', False),
+                          ('doctr', 'false', 'doctr', True),
+                          ('doctr', 'false', 'set()', False),
+                         ])
+def test_determine_push_rights(travis_branch, travis_pr, whitelist, canpush, monkeypatch):
+    monkeypatch.setenv('TRAVIS_BRANCH', travis_branch)
+    monkeypatch.setenv('TRAVIS_PULL_REQUEST', travis_pr)
+    branch_whitelist = {whitelist}
+
+    assert determine_push_rights(branch_whitelist) == canpush

--- a/doctr/tests/test_travis.py
+++ b/doctr/tests/test_travis.py
@@ -154,8 +154,6 @@ def test_sync_from_log(src, dst):
                           ('doctr', 'false', 'set()', False),
                          ])
 def test_determine_push_rights(travis_branch, travis_pr, whitelist, canpush, monkeypatch):
-    monkeypatch.setenv('TRAVIS_BRANCH', travis_branch)
-    monkeypatch.setenv('TRAVIS_PULL_REQUEST', travis_pr)
     branch_whitelist = {whitelist}
 
-    assert determine_push_rights(branch_whitelist) == canpush
+    assert determine_push_rights(branch_whitelist, travis_branch, travis_pr) == canpush

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -151,7 +151,7 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
 
     if require_master is not None:
         import warnings
-        warnings.warn("`setup_GitHub_push`'s `require_master` argument in favor of `branch_whitelist=['master']`", 
+        warnings.warn("`setup_GitHub_push`'s `require_master` argument in favor of `branch_whitelist=['master']`",
                 DeprecationWarning,
                 stacklevel=2)
         branch_whitelist.add('master')
@@ -163,7 +163,7 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
     TRAVIS_BRANCH = os.environ.get("TRAVIS_BRANCH", "")
     TRAVIS_PULL_REQUEST = os.environ.get("TRAVIS_PULL_REQUEST", "")
 
-    if any([re.compile(x).match(TRAVIS_BRANCH) for x in branch_whitelist]):
+    if not any([re.compile(x).match(TRAVIS_BRANCH) for x in branch_whitelist]):
         print("The docs are only pushed to gh-pages from master. To allow pushing from "
         "a non-master branch, use the --no-require-master flag", file=sys.stderr)
         print("This is the {TRAVIS_BRANCH} branch".format(TRAVIS_BRANCH=TRAVIS_BRANCH), file=sys.stderr)

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -159,7 +159,11 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
     if auth_type not in ['deploy_key', 'token']:
         raise ValueError("auth_type must be 'deploy_key' or 'token'")
 
-    canpush = determine_push_rights(branch_whitelist)
+    TRAVIS_BRANCH = os.environ.get("TRAVIS_BRANCH", "")
+    TRAVIS_PULL_REQUEST = os.environ.get("TRAVIS_PULL_REQUEST", "")
+
+    canpush = determine_push_rights(branch_whitelist, TRAVIS_BRANCH,
+                                    TRAVIS_PULL_REQUEST)
 
     print("Setting git attributes")
 
@@ -390,12 +394,11 @@ def push_docs(deploy_branch='gh-pages'):
     print("Pushing commit")
     run(['git', 'push', '-q', 'doctr_remote', deploy_branch])
 
-def determine_push_rights(branch_whitelist):
-
+def determine_push_rights(branch_whitelist, TRAVIS_BRANCH, TRAVIS_PULL_REQUEST):
+    """Check if Travis is running on ``master`` (or a whitelisted branch) to
+    determine if we can/should push the docs to the deploy repo
+    """
     canpush = True
-
-    TRAVIS_BRANCH = os.environ.get("TRAVIS_BRANCH", "")
-    TRAVIS_PULL_REQUEST = os.environ.get("TRAVIS_PULL_REQUEST", "")
 
     if not any([re.compile(x).match(TRAVIS_BRANCH) for x in branch_whitelist]):
         print("The docs are only pushed to gh-pages from master. To allow pushing from "


### PR DESCRIPTION
If I'm right, then we should know that this is the fix since it won't push to the `gh-pages` branch