### PR TITLE
Deprecate --no-require-master in favor of branch-whitelist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ script:
       cd docs;
       make html;
       cd ..;
-      python -m doctr deploy --sync .;
-      python -m doctr deploy --sync --gh-pages-docs docs;
-      python -m doctr deploy --sync --no-require-master  --built-docs docs/_build/html "docs-$TRAVIS_BRANCH";
-      python -m doctr deploy --no-require-master  --command "echo test" docs;
+      python -m doctr deploy --sync --branches '$^' .;
+      python -m doctr deploy --sync --branches '$^' --gh-pages-docs docs;
+      python -m doctr deploy --sync --built-docs docs/_build/html "docs-$TRAVIS_BRANCH";
+      python -m doctr deploy --command "echo test" docs;
     fi
   - if [[ "${TESTS}" == "true" ]]; then
       pyflakes doctr;
@@ -45,3 +45,5 @@ doctr:
   require-master: true
   sync: False
   lubalubadubdub: False
+  branches:
+    - '[^-].*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
       cd docs;
       make html;
       cd ..;
-      python -m doctr deploy --sync --branches 'master' .;
+      python -m doctr deploy --sync --branches 'master' -- .;
       python -m doctr deploy --sync --branches 'master' --gh-pages-docs docs;
       python -m doctr deploy --sync --built-docs docs/_build/html "docs-$TRAVIS_BRANCH";
       python -m doctr deploy --command "echo test" docs;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ script:
       cd docs;
       make html;
       cd ..;
-      python -m doctr deploy --sync --branches '$^' .;
-      python -m doctr deploy --sync --branches '$^' --gh-pages-docs docs;
+      python -m doctr deploy --sync --branches 'master' .;
+      python -m doctr deploy --sync --branches 'master' --gh-pages-docs docs;
       python -m doctr deploy --sync --built-docs docs/_build/html "docs-$TRAVIS_BRANCH";
       python -m doctr deploy --command "echo test" docs;
     fi
@@ -46,4 +46,4 @@ doctr:
   sync: False
   lubalubadubdub: False
   branches:
-    - '[^-].*'
+    - '.*'

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -16,15 +16,22 @@ useful to deploy docs from other branches, to test them out.
 The branch name on Travis is stored in the ``$TRAVIS_BRANCH`` environment
 variable. One suggestion would be to deploy the docs to a special directory
 for each branch. The following will deploy the docs to ``docs`` on master and
-:raw-html:`<code>docs-<i>branch</i></code>` on *branch*.
+:raw-html:`<code>docs-<i>branch</i></code>` on *branch*. You can use the
+``branch-whitelist`` option in ``.travis.yml`` to list explicitly allowed
+branches. ``branch_whitelist`` takes list of regular expressions.
 
 .. code:: yaml
 
    - if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
-       doctr deploy --gh-pages-docs docs;
+       doctr deploy "docs";
      else
-       doctr deploy --no-require-master --gh-pages-docs "docs-$TRAVIS_BRANCH";
+       doctr deploy "docs-$TRAVIS_BRANCH";
      fi
+   ...
+   doctr:
+     branch-whitelist:
+      - master
+      - [0-9]+\.x
 
 This will not remove the docs after the branch is merged. You will need to do
 that manually.

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -17,8 +17,8 @@ The branch name on Travis is stored in the ``$TRAVIS_BRANCH`` environment
 variable. One suggestion would be to deploy the docs to a special directory
 for each branch. The following will deploy the docs to ``docs`` on master and
 :raw-html:`<code>docs-<i>branch</i></code>` on *branch*. You can use the
-``branch-whitelist`` option in ``.travis.yml`` to list explicitly allowed
-branches. ``branch_whitelist`` takes list of regular expressions.
+``branches`` option in ``.travis.yml`` to list explicitly allowed
+branches. ``branches`` takes list of regular expressions.
 
 .. code:: yaml
 
@@ -29,7 +29,7 @@ branches. ``branch_whitelist`` takes list of regular expressions.
      fi
    ...
    doctr:
-     branch-whitelist:
+     branches:
       - master
       - [0-9]+\.x
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -134,7 +134,7 @@ options available.
     deploy_parser_add_argument('--built-docs', default=None,
         help="""Location of the built html documentation to be deployed to
         gh-pages. If not specified, Doctr will try to automatically detect build location""")
-    deploy_parser.add_argument('--deploy-branch-name', default=None,
+    deploy_parser_add_argument('--deploy-branch-name', default=None,
                                help="""Name of the branch to deploy to (default: 'master' for ``*.github.io``
                                repos, 'gh-pages' otherwise)""")
     deploy_parser_add_argument('--tmp-dir', default=None,
@@ -222,8 +222,6 @@ def deploy(args, parser):
     if not args.force and not on_travis():
         parser.error("doctr does not appear to be running on Travis. Use "
             "doctr deploy --force to run anyway.")
-
-    config = get_config()
 
     if args.tmp_dir:
         parser.error("The --tmp-dir flag has been removed (doctr no longer uses a temporary directory when deploying).")

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -119,9 +119,9 @@ options available.
 
     subcommand = parser.add_subparsers(title='subcommand', dest='subcommand')
 
-    deploy_parser = subcommand.add_parser('deploy', help="""Deploy the docs to GitHub from Travis.""")
-    deploy_parser.set_defaults(func=deploy)
-    deploy_parser_add_argument = make_parser_with_config_adder(deploy_parser, config)
+    _deploy_parser = subcommand.add_parser('deploy', help="""Deploy the docs to GitHub from Travis.""")
+    _deploy_parser.set_defaults(func=deploy)
+    deploy_parser_add_argument = make_parser_with_config_adder(_deploy_parser, config)
     deploy_parser_add_argument('--force', action='store_true', help="""Run the deploy command even
     if we do not appear to be on Travis.""")
     deploy_parser_add_argument('deploy_directory', type=str, nargs='?',
@@ -144,7 +144,7 @@ options available.
     deploy_parser_add_argument('--no-require-master', dest='require_master', action='store_false',
         default=True, help="DEPRECATED: Allow docs to be pushed from a branch other than master: "
                            "use `branches` option.")
-    deploy_parser.add_argument('--branches', dest='branches', default=['master'], nargs='*',
+    deploy_parser_add_argument('--branches', dest='branches', default=['master'], nargs='*',
         help="""List of patterns for acceptable branch to push docs from""", metavar='PATTERN')
     deploy_parser_add_argument('--command', default=None, help="""Command to
         be run before committing and pushing. If the command creates

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -142,7 +142,8 @@ options available.
     deploy_parser_add_argument('--deploy-repo', default=None, help="""Repo to
         deploy the docs to. By default, it deploys to the repo Doctr is run from.""")
     deploy_parser_add_argument('--no-require-master', dest='require_master', action='store_false',
-        default=True, help="""Allow docs to be pushed from a branch other than master""")
+        default=True, help="DEPRECATED: Allow docs to be pushed from a branch other than master: "
+                           "use `branch-whitelist` option in `.travis.yml`")
     deploy_parser_add_argument('--command', default=None, help="""Command to
         be run before committing and pushing. If the command creates
         additional files that should be deployed, they should be added to the
@@ -246,8 +247,14 @@ def deploy(args, parser):
 
     current_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
     try:
+        if args.require_master is not None:
+            import warnings
+            warnings.warn("`setup_GitHub_push`'s `require_master` argument in favor of `branch-whitelist` configuration option in `.travis.yml`",
+                DeprecationWarning,
+                stacklevel=2)
+
         branch_whitelist = {'master'} if args.require_master else set({})
-        branch_whitelist.update(set(config.get('branches',set({}))))
+        branch_whitelist.update(set(config.get('branches', set({}))))
 
         can_push = setup_GitHub_push(deploy_repo, deploy_branch=deploy_branch,
                                      auth_type='token' if args.token else 'deploy_key',

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -133,7 +133,7 @@ def get_current_repo():
     _, org, git_repo = remote_url.rsplit('.git', 1)[0].rsplit('/', 2)
     return (org + '/' + git_repo)
 
-def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github_deploy_key.enc', require_master=None, branch_whitelist=None, deploy_branch='gh-pages'):
+def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github_deploy_key.enc', branch_whitelist=None, deploy_branch='gh-pages'):
     """
     Setup the remote to push to GitHub (to be run on Travis).
 
@@ -148,13 +148,6 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
 
     if not branch_whitelist:
         branch_whitelist={'master'}
-
-    if require_master is not None:
-        import warnings
-        warnings.warn("`setup_GitHub_push`'s `require_master` argument in favor of `branch_whitelist=['master']`",
-                DeprecationWarning,
-                stacklevel=2)
-        branch_whitelist.add('master')
 
     if auth_type not in ['deploy_key', 'token']:
         raise ValueError("auth_type must be 'deploy_key' or 'token'")
@@ -402,7 +395,7 @@ def determine_push_rights(branch_whitelist, TRAVIS_BRANCH, TRAVIS_PULL_REQUEST):
 
     if not any([re.compile(x).match(TRAVIS_BRANCH) for x in branch_whitelist]):
         print("The docs are only pushed to gh-pages from master. To allow pushing from "
-        "a non-master branch, use the --no-require-master flag", file=sys.stderr)
+        "a non-master branch, use the `branch-whitelist` option in `.travis.yml`", file=sys.stderr)
         print("This is the {TRAVIS_BRANCH} branch".format(TRAVIS_BRANCH=TRAVIS_BRANCH), file=sys.stderr)
         canpush = False
 

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -395,7 +395,7 @@ def determine_push_rights(branch_whitelist, TRAVIS_BRANCH, TRAVIS_PULL_REQUEST):
 
     if not any([re.compile(x).match(TRAVIS_BRANCH) for x in branch_whitelist]):
         print("The docs are only pushed to gh-pages from master. To allow pushing from "
-        "a non-master branch, use the `branch-whitelist` option in `.travis.yml`", file=sys.stderr)
+        "a non-master branch, use the `branches` option.", file=sys.stderr)
         print("This is the {TRAVIS_BRANCH} branch".format(TRAVIS_BRANCH=TRAVIS_BRANCH), file=sys.stderr)
         canpush = False
 


### PR DESCRIPTION
it still seem to be relatively complicated to pass a list as a CLI flag,
so `.travis.yml` only.

I can also have --no-require-master still exist and add `.*` to the
whitelist.