### PR TITLE
re-enable pushing from non-master branches

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -37,7 +37,7 @@ from textwrap import dedent
 from .local import (generate_GitHub_token, encrypt_variable, encrypt_file,
     upload_GitHub_deploy_key, generate_ssh_key, check_repo_exists, GitHub_login)
 from .travis import (setup_GitHub_push, commit_docs, push_docs,
-    get_current_repo, sync_from_log, find_sphinx_build_dir, run)
+    get_current_repo, sync_from_log, find_sphinx_build_dir, run, get_travis_branch)
 from . import __version__
 
 def make_parser_with_config_adder(parser, config):
@@ -246,7 +246,7 @@ def deploy(args, parser):
 
     current_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
     try:
-        branch_whitelist = {'master'} if args.require_master else set({})
+        branch_whitelist = {'master'} if args.require_master else set(get_travis_branch())
         branch_whitelist.update(set(config.get('branches',set({}))))
 
         can_push = setup_GitHub_push(deploy_repo, deploy_branch=deploy_branch,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -133,6 +133,20 @@ def get_current_repo():
     _, org, git_repo = remote_url.rsplit('.git', 1)[0].rsplit('/', 2)
     return (org + '/' + git_repo)
 
+def get_travis_branch():
+    """Get the name of the branch that the PR is from.
+
+    Note that this is not simply ``$TRAVIS_BRANCH``. the ``push`` build will
+    use the correct branch (the branch that the PR is from) but the ``pr``
+    build will use the _target_ of the PR (usually master). So instead, we ask
+    for ``$TRAVIS_PULL_REQUEST_BRANCH`` if it's a PR build, and
+    ``$TRAVIS_BRANCH`` if it's a push build.
+    """
+    if os.environ.get("TRAVIS_PULL_REQUEST", "") == "true":
+        return os.environ.get("TRAVIS_PULL_REQUEST_BRANCH", "")
+    else:
+        return os.environ.get("TRAVIS_BRANCH", "")
+
 def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github_deploy_key.enc', require_master=None, branch_whitelist=None, deploy_branch='gh-pages'):
     """
     Setup the remote to push to GitHub (to be run on Travis).


### PR DESCRIPTION
This was raised by @jorisvandenbossche -- it looks like some part of the `branch_whitelist` additions removed the functionality provided by `--no-require-master`

I know that that's a flag up for deprecation, but it should at least work while we still offer it