### PR TITLE
updating instructions so they're more clear

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ or conda
 Usage
 -----
 
-Run doctr
-~~~~~~~~~
+Run doctr configure
+~~~~~~~~~~~~~~~~~~~
 
 First use doctr to generate the necessary key files so that travis can push
 to your gh-pages (or other) branch.
@@ -39,9 +39,9 @@ Run
    doctr configure
 
 and enter your data. You will need your GitHub username and password, and the
-repo you want to build the docs for.
+repo organization / name for which you want to build the docs.
 
-That repo should already be setup with Travis. We recommend enabling
+**Note**: That repo should already be set up with Travis. We recommend enabling
 `branch protection <https://help.github.com/articles/about-protected-branches/>`_
 for the ``gh-pages`` branch and other branches, as the deploy key
 used by doctr has the ability to push to any branch in your repo.
@@ -78,20 +78,20 @@ Your ``.travis.yml`` file should look something like this:
      - cd ..
      - doctr deploy .
 
+See `the travis config file
+-<https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
+-itself for example.
 
-See `the Doctr travis
-file <https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ for example.
+   **Note:** You can deploy ``doctr`` to a different folder by giving it a different path
+   in the call to ``deploy``. E.g., ``doctr deploy docs/``.
 
-    **Note:** You can deploy ``doctr`` to a different folder by giving it a different path
-    in the call to ``deploy``. E.g., ``doctr deploy docs/``.
+   **Warning:** Be sure to add ``set -e`` in ``script``, to prevent ``doctr`` from  running
+   when the docs build fails.
 
-    **Warning:** Be sure to add ``set -e`` in ``script``, to prevent ``doctr`` from running
-    when the docs build fails.
-
-    **Warning:** Put ``doctr deploy .`` in the ``script`` section of your ``.travis.yml``. If
-    you use ``after_success``, it will `not cause
-    <https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
-    the build to fail.
+   **Warning:** Put ``doctr deploy .`` in the ``script`` section of your ``.travis.yml``. If
+   you use ``after_success``, it will `not cause
+   <https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
+   the build to fail.
 
 Commit your new files and build your site
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,12 @@ or conda
 Usage
 -----
 
+Run doctr
+~~~~~~~~~
+
+First use doctr to generate the necessary key files so that travis can push
+to your gh-pages (or other) branch.
+
 Run
 
 .. code::
@@ -38,55 +44,70 @@ repo you want to build the docs for.
 That repo should already be setup with Travis. We recommend enabling
 `branch protection <https://help.github.com/articles/about-protected-branches/>`_
 for the ``gh-pages`` branch and other branches, as the deploy key
-used by Doctr has the ability to push to any branch in your repo.
+used by doctr has the ability to push to any branch in your repo.
 
-Then add the stuff to your ``.travis.yml`` and commit the encrypted deploy
-key. The command above will tell you what to do. You should also have
-something like
+Edit your travis file
+~~~~~~~~~~~~~~~~~~~~~
+
+Doctr will output a bunch of text as well as instructions for next steps. You
+need to edit your ``.travis.yml`` with this text. It contains the secure key
+that lets travis communicate with your github repository, as well as the
+code to run (in ``script:``) in order to build the docs and deploy doctr.
+
+Your ``.travis.yml`` file should look something like this:
 
 .. code:: yaml
 
+   # doctr requires python >=3.5
    language: python
    python:
      - 3.6
 
+   # This gives doctr the key we've generated
    sudo: false
    env:
      global:
        secure: "<your secure key from doctr here>"
 
+   # This is the script to build the docs on travis, then deploy
    script:
      - set -e
      - pip install sphinx doctr
      - cd docs
      - make html
      - cd ..
-     - doctr deploy
+     - doctr deploy .
 
 
-in your ``.travis.yml``. See `the one
-<https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
-itself for example.
+See `the Doctr travis
+file <https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ for example.
 
-.. warning::
+    **Note:** You can deploy ``doctr`` to a different folder by giving it a different path
+    in the call to ``deploy``. E.g., ``doctr deploy docs/``.
 
-   Be sure to add ``set -e`` in ``script``, to prevent ``doctr`` from running
-   when the docs build fails.
+    **Warning:** Be sure to add ``set -e`` in ``script``, to prevent ``doctr`` from running
+    when the docs build fails.
 
-.. warning::
+    **Warning:** Put ``doctr deploy .`` in the ``script`` section of your ``.travis.yml``. If
+    you use ``after_success``, it will `not cause
+    <https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
+    the build to fail.
 
-   Put ``doctr deploy`` in the ``script`` section of your ``.travis.yml``. If
-   you use ``after_success``, it will `not cause
-   <https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build>`_
-   the build to fail.
+Commit your new files and build your site
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+``doctr configure`` will create a new file that contains your key. Commit this as
+well as the changes to ``.travis.yml``. Once you push to github, travis should
+now automatically build your documentation and deploy it.
 
+Notes 
+-----
 
-**Heads up:** Doctr requires Python 3.5 or newer. Be sure to run it in a
+**Doctr requires Python 3.5 or newer.** Be sure to run it in a
 Python 3.5 or newer section of your build matrix. It should be in the same
 build in your build matrix as your docs build, as it reuses that.
 
-Another suggestion: If you use Sphinx, add
+**To force an error on warnings** if you use Sphinx, add
 
 .. code::
 
@@ -95,9 +116,9 @@ Another suggestion: If you use Sphinx, add
 to your Sphinx ``Makefile``. This will make Sphinx error even if there are
 warnings, keeping your docs more accurate.
 
-**Note: Doctr does not require Sphinx. It will work with deploying anything to
-GitHub pages.** However, if you do use Sphinx, doctr will find your Sphinx
-docs automatically (otherwise use ``doctr deploy --built-docs <DOCS PATH>``).
+**Doctr does not require Sphinx.** It will work with deploying anything to
+GitHub pages. However, if you do use Sphinx, doctr will find your Sphinx
+docs automatically (otherwise use ``doctr deploy . --built-docs <DOCS PATH>``).
 
 FAQ
 ---

--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,7 @@ Your ``.travis.yml`` file should look something like this:
      - doctr deploy .
 
 See `the travis config file
-<https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
--itself for example.
+<https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr itself for example.
 
    **Note:** You can deploy ``doctr`` to a different folder by giving it a different path
    in the call to ``deploy``. E.g., ``doctr deploy docs/``.

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Your ``.travis.yml`` file should look something like this:
      - doctr deploy .
 
 See `the travis config file
--<https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
+<https://github.com/drdoctr/doctr/blob/master/.travis.yml>`_ used by Doctr
 -itself for example.
 
    **Note:** You can deploy ``doctr`` to a different folder by giving it a different path

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -218,7 +218,7 @@ def on_travis():
 def deploy(args, parser):
     if not args.force and not on_travis():
         parser.error("doctr does not appear to be running on Travis. Use "
-            "doctr deploy --force to run anyway.")
+                     "doctr deploy <target-dir> --force to run anyway.")
 
     config = get_config()
 
@@ -355,7 +355,10 @@ def configure(args, parser):
 
 
         print(dedent("""\
-        {N}. Commit the file {keypath}.enc.
+        {N}. Add the file {keypath}.enc to be staged for commit:
+
+            git add {keypath}.enc
+
         """.format(keypath=args.key_path, N=N)))
 
     options = ''
@@ -365,28 +368,31 @@ def configure(args, parser):
         options += ' --deploy-repo {deploy_repo}'.format(deploy_repo=deploy_repo)
 
     print(dedent("""\
-    {N}. Add
+    {N}. Add these lines to your `.travis.yml` file:
 
         script:
           - set -e
           - # Command to build your docs
           - pip install doctr
-          - doctr deploy{options} <deploy_directory>
-
-    to the docs build of your .travis.yml.  The 'set -e' prevents doctr from
-    running when the docs build fails. Use the 'script' section so that if
-    doctr fails it causes the build to fail.
-    """.format(options=options, N=N)))
-
-    print(dedent("""\
-    {N}. Put
+          - doctr deploy{options} <target-directory>
 
         env:
-          global:
+          global:`
             - secure: "{encrypted_variable}"
 
-    in your .travis.yml.
-    """.format(encrypted_variable=encrypted_variable.decode('utf-8'), N=N)))
+    """.format(options=options, N=N, encrypted_variable=encrypted_variable.decode('utf-8'))))
+
+    print(dedent("""\
+    {N}. Commit and push these changes to your github repository.
+        The docs should now build automatically on travis.
+
+    """.format(N=N)))
+
+    print(dedent("""\
+    Note: the `set -e` prevents doctr from running when the docs build
+      fails. We put this code under `script:` so that if doctr fails it causes
+      the build to fail.
+    """))
 
 def main():
     config = get_config()


### PR DESCRIPTION
This is a short edit to the instructions printed for the CLI and in the README file. I found them a bit confusing the first time I tried this, so this is an attempt at making it a little clearer. It also updates the README which can be seen [here](https://github.com/choldgraf/doctr/tree/update_instructions).

LMK if there are some other improvements along these lines I can make or if I need to explain something differently.

Here's what the final step of `doctr configure` outputs now:

```
================== You should now do the following ==================

1. Add the file github_deploy_key.enc to be staged for commit:

    git add github_deploy_key.enc


2. Add these lines to your `.travis.yml` file:

    script:
      - set -e
      - # Command to build your docs
      - pip install doctr
      - doctr deploy <target-directory>

    env:
      global:`
        - secure: "JUUwow9OkUu3hrLBwJT6XCt6gS8ttNY3QoN9V1wLw4b11UTbdICUk14+hsjoQpwIvBpfYMvQ4t9BgAur/TuMB0tbjuXIXd8swqKnsbT5pMT9MFJSEnSjj0xs2+yT0BKYFwmq4JvvKDltVm0mE5zG+xo1WKLmBClbmH0WdnFs9u+CUs2bJvk8g21J9Z4l2Etc+ZoYhe/kB6lw9BAxiebzbbEU2z0MeP0umMllAH68ZdGSRvjfOdmyhn4ob2E+hnZWp+hSBQCfMw5EoU2+VnMywIvywco0cWGGPUaEf5dpPCLChPSB4WESyJVSP7hH2m9q0o2Fw2SO11cjy1XyGOnPJqslHTO8lc/N5cn6Hos7B+fX6M9j7vevQCa1W6ex2p3UbFvbMRP/vm+ObqFOUz/npKtDjYo77QVUnHh0D66LlGHAKt+emjrVzo0Z3bZDqyXuQPUWC5Sph618i0vMG5/JXuu2Qb5pW3RlcC72BV9g8cpu5dmnRR3j2Uvm8NDB8w1RR8a7IpnM8CPKKqt+Ckzp8vQVJqJWY+fPiaIPWXmV1PUBA8cY+vA94rWoCX3zP5hZkvu033gcEGL3fZwBRFe2gVlD+u6VS7bqwWjkG7IMCMjGTX6NCptvWC1Z3V5jHHQlJp/D8ZBMGmKm4PsDLUk+wmdkJ17Pj0HDWmbzWoQlpDo="


3. Commit and push these changes to your github repository.
    The docs should now build automatically on travis.


Note: the `set -e` prevents doctr from running when the docs build
  fails. We put this code under `script:` so that if doctr fails it causes
  the build to fail.
```