### PR TITLE
ENH: Support pushing to *.github.io from other repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
       python -m doctr deploy --no-require-master  --command "echo test; ls; touch docs/_build/html/test" docs;
       # Test syncing a tracked file with a change
       python -m doctr deploy --sync . --built-docs test;
+      python -m doctr deploy --deploy-repo drdoctr/drdoctr.github.io docs;
     fi
   - if [[ "${TESTS}" == "true" ]]; then
       pyflakes doctr;

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -247,7 +247,7 @@ def deploy(args, parser):
     if args.deploy_branch_name:
         deploy_branch = args.deploy_branch_name
     else:
-        deploy_branch = 'master' if deploy_dir.endswith(('.github.io', '.github.com')) else 'gh-pages'
+        deploy_branch = 'master' if deploy_repo.endswith(('.github.io', '.github.com')) else 'gh-pages'
 
     current_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
     try:

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -15,6 +15,8 @@ import time
 
 from cryptography.fernet import Fernet
 
+DOCTR_WORKING_BRANCH = '__doctr_working_branch'
+
 def decrypt_file(file, key):
     """
     Decrypts the file ``file``.
@@ -242,13 +244,9 @@ def checkout_deploy_branch(deploy_branch, canpush=True):
     Checkout the deploy branch, creating it if it doesn't exist.
     """
     #create empty branch with .nojekyll if it doesn't already exist
-    new_deploy_branch = create_deploy_branch(deploy_branch, push=canpush)
-    print("Checking out {}".format(deploy_branch))
-    local_deploy_branch_exists = deploy_branch in subprocess.check_output(['git', 'branch']).decode('utf-8').split()
-    if new_deploy_branch or local_deploy_branch_exists:
-        run(['git', 'checkout', deploy_branch])
-    else:
-        run(['git', 'checkout', '-b', deploy_branch, '--track', 'doctr_remote/{}'.format(deploy_branch)])
+    create_deploy_branch(deploy_branch, push=canpush)
+    print("Checking out doctr working branch tracking doctr_remote/{}".format(deploy_branch))
+    run(['git', 'checkout', '-B', DOCTR_WORKING_BRANCH, '--track', 'doctr_remote/{}'.format(deploy_branch)])
     print("Done")
 
 def deploy_branch_exists(deploy_branch):
@@ -448,7 +446,7 @@ def push_docs(deploy_branch='gh-pages', retries=3):
         print("Pulling")
         code = run(['git', 'pull', 'doctr_remote', deploy_branch])
         print("Pushing commit")
-        code = run(['git', 'push', '-q', 'doctr_remote', deploy_branch], exit=False)
+        code = run(['git', 'push', '-q', 'doctr_remote', '{}:{}'.format(DOCTR_WORKING_BRANCH, deploy_branch)])
         if code:
             retries -= 1
             print("Push failed, retrying")


### PR DESCRIPTION
Doctr already supports publishing to the master branch of an `org/org.github.io` repo. I believe it does not support pushing from `org/some_repo` (and perhaps multiple other repos) into `org/org.github.io`. (Why do this? Different projects in an org can publish into subdirectories of one org-wide gh-pages repo and get a nice URL structure: org.github.io/repo_a, org.github.io/repo_b, etc. You could do this with separate gh-pages branches, but it's nice to keep the large build projects off in their own org-wide repo and keep the repos' branches light. The projects matplotlib, cmocean, and trackpy all do this.)

The issue arises from `deploy_branch` being`master`. Local `master` refers to the history of `org/some_repo`, while `doctr_remote/master` refers to the history of `org/org.github.io` and doctr mixes them up.

I have resolved this by doing the local work on a special branch with an unambiguous name that tracks `doctr_remote/{deploy_branch}` and is explicitly pushed to it.

I *think* this modification does not break existing use cases but someone more familiar with the codebase should take a careful look. This [Travis build](https://travis-ci.org/NSLS-II/docs/builds/234984797) shows it operating successfully for my use case of off this PR.