### PR TITLE
fix travis pr check

### DIFF
--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -148,7 +148,7 @@ def get_travis_branch():
     for ``$TRAVIS_PULL_REQUEST_BRANCH`` if it's a PR build, and
     ``$TRAVIS_BRANCH`` if it's a push build.
     """
-    if os.environ.get("TRAVIS_PULL_REQUEST", "") == "true":
+    if os.environ.get("TRAVIS_PULL_REQUEST", "") != "false":
         return os.environ.get("TRAVIS_PULL_REQUEST_BRANCH", "")
     else:
         return os.environ.get("TRAVIS_BRANCH", "")


### PR DESCRIPTION
based on the docs : https://docs.travis-ci.com/user/environment-variables/

TRAVIS_PULL_REQUEST: The pull request number if the current job is a pull request, “false” if it’s not a pull request.

This closes #199 