### PR TITLE
stash before checking out in case files have changed

### DIFF
--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -217,6 +217,7 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
 
     print("Fetching doctr remote")
     run(['git', 'fetch', 'doctr_remote'])
+    run(['git', 'stash'])
 
     #create empty branch with .nojekyll if it doesn't already exist
     new_deploy_branch = create_deploy_branch(deploy_branch, push=canpush)


### PR DESCRIPTION
I came across an error that appears to occur when the process of building docs changes one of the files in the repo. I got this error in the travis logs...

```
$ doctr deploy --deploy-repo gallantlab/gallantlab.github.io --deploy-branch-name test-docs --no-require-master html
HEAD is now at c0c6b4c... remove examples that don't work
M	filestore/db/S1/overlays.svg
Identity added: /home/travis/.ssh/github_deploy_key (/home/travis/.ssh/github_deploy_key)
Warning: Permanently added the RSA host key for IP address '192.30.253.113' to the list of known hosts.
warning: no common commits
From github.com:gallantlab/gallantlab.github.io
 * [new branch]      gh-pages   -> doctr_remote/gh-pages
 * [new branch]      master     -> doctr_remote/master
 * [new branch]      test-docs  -> doctr_remote/test-docs
error: Your local changes to the following files would be overwritten by checkout:
	filestore/db/S1/overlays.svg
Please, commit your changes or stash them before you can switch branches.
Aborting
Setting git attributes
git config --global user.name 'Doctr (Travis CI)'
git config --global user.email drdoctr@users.noreply.github.com
Adding doctr remote
ssh-add /home/travis/.ssh/github_deploy_key
git remote add doctr_remote git@github.com:gallantlab/gallantlab.github.io.git
Fetching doctr remote
git fetch doctr_remote
Checking out test-docs
git checkout -b test-docs --track doctr_remote/test-docs
```

This change fixes the error and travis builds successfully. I may not be aware of any unintended consequences, but let me know what you think. Thank you!