### PR TITLE
Copy the --built-docs to a temporary directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
       python -m doctr deploy --sync .;
       python -m doctr deploy --sync --gh-pages-docs docs;
       python -m doctr deploy --sync --no-require-master  --built-docs docs/_build/html "docs-$TRAVIS_BRANCH";
-      python -m doctr deploy --no-require-master  --command "echo test; ls" docs;
+      python -m doctr deploy --no-require-master  --command "echo test; ls; touch docs/_build/html/test" docs;
     fi
   - if [[ "${TESTS}" == "true" ]]; then
       pyflakes doctr;

--- a/doctr/__init__.py
+++ b/doctr/__init__.py
@@ -2,16 +2,17 @@ from .local import (encrypt_variable, encrypt_file, GitHub_post,
     generate_GitHub_token, upload_GitHub_deploy_key, generate_ssh_key,
     check_repo_exists)
 from .travis import (decrypt_file, setup_deploy_key, get_token, run,
-    setup_GitHub_push, deploy_branch_exists, create_deploy_branch,
-    copy_to_tmp, sync_from_log, commit_docs, push_docs, get_current_repo,
-    find_sphinx_build_dir)
+    setup_GitHub_push, checkout_deploy_branch, deploy_branch_exists,
+    create_deploy_branch, copy_to_tmp, sync_from_log, commit_docs, push_docs,
+    get_current_repo, find_sphinx_build_dir)
 
 __all__ = [
     'encrypt_variable', 'encrypt_file', 'GitHub_post',
     'generate_GitHub_token', 'upload_GitHub_deploy_key', 'generate_ssh_key',
     'check_repo_exists',
 
-    'decrypt_file', 'setup_deploy_key', 'get_token', 'run', 'setup_GitHub_push', 'deploy_branch_exists',
+    'decrypt_file', 'setup_deploy_key', 'get_token', 'run',
+    'setup_GitHub_push', 'checkout_deploy_branch', 'deploy_branch_exists',
     'create_deploy_branch', 'copy_to_tmp', 'sync_from_log', 'commit_docs', 'push_docs', 'get_current_repo', 'find_sphinx_build_dir'
 ]
 

--- a/doctr/__init__.py
+++ b/doctr/__init__.py
@@ -2,8 +2,9 @@ from .local import (encrypt_variable, encrypt_file, GitHub_post,
     generate_GitHub_token, upload_GitHub_deploy_key, generate_ssh_key,
     check_repo_exists)
 from .travis import (decrypt_file, setup_deploy_key, get_token, run,
-    setup_GitHub_push, deploy_branch_exists, create_deploy_branch, sync_from_log,
-    commit_docs, push_docs, get_current_repo, find_sphinx_build_dir)
+    setup_GitHub_push, deploy_branch_exists, create_deploy_branch,
+    copy_to_tmp, sync_from_log, commit_docs, push_docs, get_current_repo,
+    find_sphinx_build_dir)
 
 __all__ = [
     'encrypt_variable', 'encrypt_file', 'GitHub_post',
@@ -11,7 +12,7 @@ __all__ = [
     'check_repo_exists',
 
     'decrypt_file', 'setup_deploy_key', 'get_token', 'run', 'setup_GitHub_push', 'deploy_branch_exists',
-    'create_deploy_branch', 'sync_from_log', 'commit_docs', 'push_docs', 'get_current_repo', 'find_sphinx_build_dir'
+    'create_deploy_branch', 'copy_to_tmp', 'sync_from_log', 'commit_docs', 'push_docs', 'get_current_repo', 'find_sphinx_build_dir'
 ]
 
 from ._version import get_versions

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -267,6 +267,9 @@ def deploy(args, parser):
             if args.temp_dir:
                 built_docs = copy_to_tmp(built_docs)
 
+        # Reset in case there are modified files that are tracked in the
+        # dpeloy branch.
+        run(['git', 'reset', '--hard'])
         checkout_deploy_branch(deploy_branch, canpush=canpush)
 
         if args.sync:

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -37,7 +37,7 @@ from .local import (generate_GitHub_token, encrypt_variable, encrypt_file,
     upload_GitHub_deploy_key, generate_ssh_key, check_repo_exists, GitHub_login)
 from .travis import (setup_GitHub_push, commit_docs, push_docs,
     get_current_repo, sync_from_log, find_sphinx_build_dir, run,
-    get_travis_branch, copy_to_tmp)
+    get_travis_branch, copy_to_tmp, checkout_deploy_branch)
 from . import __version__
 
 def make_parser_with_config_adder(parser, config):
@@ -260,9 +260,9 @@ def deploy(args, parser):
                                      branch_whitelist=branch_whitelist)
 
         if args.command:
-            run(['git', 'checkout', get_travis_branch()])
             run(args.command, shell=True)
-            run(['git', 'checkout', deploy_branch])
+
+        checkout_deploy_branch(deploy_branch, canpush=canpush)
 
         if args.sync:
             built_docs = args.built_docs or find_sphinx_build_dir()

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -254,7 +254,7 @@ def deploy(args, parser):
         branch_whitelist = {'master'} if args.require_master else set(get_travis_branch())
         branch_whitelist.update(set(config.get('branches',set({}))))
 
-        can_push = setup_GitHub_push(deploy_repo, deploy_branch=deploy_branch,
+        canpush = setup_GitHub_push(deploy_repo, deploy_branch=deploy_branch,
                                      auth_type='token' if args.token else 'deploy_key',
                                      full_key_path=args.key_path,
                                      branch_whitelist=branch_whitelist)
@@ -280,7 +280,7 @@ def deploy(args, parser):
 
         changes = commit_docs(added=added, removed=removed)
         if changes:
-            if can_push and args.push:
+            if canpush and args.push:
                 push_docs(deploy_branch)
             else:
                 print("Don't have permission to push. Not trying.")

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -259,6 +259,11 @@ def deploy(args, parser):
                                      full_key_path=args.key_path,
                                      branch_whitelist=branch_whitelist)
 
+        if args.command:
+            run(['git', 'checkout', get_travis_branch()])
+            run(args.command, shell=True)
+            run(['git', 'checkout', deploy_branch])
+
         if args.sync:
             built_docs = args.built_docs or find_sphinx_build_dir()
             if args.temp_dir:
@@ -272,11 +277,6 @@ def deploy(args, parser):
 
         else:
             added, removed = [], []
-
-        if args.command:
-            run(['git', 'checkout', get_travis_branch()])
-            run(args.command, shell=True)
-            run(['git', 'checkout', deploy_branch])
 
         changes = commit_docs(added=added, removed=removed)
         if changes:

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -262,13 +262,14 @@ def deploy(args, parser):
         if args.command:
             run(args.command, shell=True)
 
-        checkout_deploy_branch(deploy_branch, canpush=canpush)
-
         if args.sync:
             built_docs = args.built_docs or find_sphinx_build_dir()
             if args.temp_dir:
                 built_docs = copy_to_tmp(built_docs)
 
+        checkout_deploy_branch(deploy_branch, canpush=canpush)
+
+        if args.sync:
             log_file = os.path.join(deploy_dir, '.doctr-files')
 
             print("Moving built docs into place")

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 import glob
 import re
+import pathlib
+import tempfile
 
 from cryptography.fernet import Fernet
 
@@ -293,6 +295,19 @@ def find_sphinx_build_dir():
 #
 # TRAVIS_JOB_NUMBER = os.environ.get("TRAVIS_JOB_NUMBER", '')
 # ACTUAL_TRAVIS_JOB_NUMBER = TRAVIS_JOB_NUMBER.split('.')[1]
+
+def copy_to_tmp(directory):
+    """
+    Copies the contents of directory to a temporary directory, and returns the
+    copied location.
+    """
+    tmp_dir = tempfile.mkdtemp()
+    # Use pathlib because os.path.basename is different depending on whether
+    # the path ends in a /
+    p = pathlib.Path(directory)
+    new_dir = os.path.join(tmp_dir, p.name)
+    shutil.copytree(directory, new_dir)
+    return new_dir
 
 def sync_from_log(src, dst, log_file):
     """

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -220,6 +220,12 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
     print("Fetching doctr remote")
     run(['git', 'fetch', 'doctr_remote'])
 
+    return canpush
+
+def checkout_deploy_branch(deploy_branch, canpush=True):
+    """
+    Checkout the deploy branch, creating it if it doesn't exist.
+    """
     #create empty branch with .nojekyll if it doesn't already exist
     new_deploy_branch = create_deploy_branch(deploy_branch, push=canpush)
     print("Checking out {}".format(deploy_branch))
@@ -229,8 +235,6 @@ def setup_GitHub_push(deploy_repo, auth_type='deploy_key', full_key_path='github
     else:
         run(['git', 'checkout', '-b', deploy_branch, '--track', 'doctr_remote/{}'.format(deploy_branch)])
     print("Done")
-
-    return canpush
 
 def deploy_branch_exists(deploy_branch):
     """


### PR DESCRIPTION
This makes it possible to deploy committed files, and avoids issues with
checkout out gh-pages if tracked files would be modified by checkout.

Fixes #202
Fixes #214
Closes #211