### PR TITLE
Use the "ours" merge strategy on merge

### DIFF
--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -446,7 +446,7 @@ def push_docs(deploy_branch='gh-pages', retries=3):
     code = 1
     while code and retries:
         print("Pulling")
-        code = run(['git', 'pull', 'doctr_remote', deploy_branch])
+        code = run(['git', 'pull', '-s', 'recursive', '-X', 'ours', 'doctr_remote', deploy_branch])
         print("Pushing commit")
         code = run(['git', 'push', '-q', 'doctr_remote', deploy_branch], exit=False)
         if code:


### PR DESCRIPTION
This should avoid issues when there are merge conflicts on gh-pages from other
non-doctr commits. See for instance
https://travis-ci.org/ergs/rg-db-public/builds/254625403.