### PR TITLE
Actually sync the drdoctr.github.io build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
       python -m doctr deploy --no-require-master  --command "echo test; ls; touch docs/_build/html/test" docs;
       # Test syncing a tracked file with a change
       python -m doctr deploy --sync . --built-docs test;
-      python -m doctr deploy --deploy-repo drdoctr/drdoctr.github.io docs;
+      python -m doctr deploy --sync --deploy-repo drdoctr/drdoctr.github.io docs;
     fi
   - if [[ "${TESTS}" == "true" ]]; then
       pyflakes doctr;


### PR DESCRIPTION
This won't work until we add a deploy key, which we can't do until we make it so we can use more than one deploy key. 