### PR TITLE
Don't capture the command output when there is no token

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -39,11 +39,8 @@ from .local import (generate_GitHub_token, encrypt_variable, encrypt_file,
     GitHub_login, guess_github_repo)
 from .travis import (setup_GitHub_push, commit_docs, push_docs,
     get_current_repo, sync_from_log, find_sphinx_build_dir, run,
-    get_travis_branch, copy_to_tmp, checkout_deploy_branch)
+    get_travis_branch, copy_to_tmp, checkout_deploy_branch, red)
 from . import __version__
-
-def red(text):
-    return "\033[31m%s\033[0m" % text
 
 def make_parser_with_config_adder(parser, config):
     """factory function for a smarter parser:

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -95,7 +95,7 @@ def run_command_hiding_token(args, token, shell=False):
     else:
         command = args
     command = command.replace(token.decode('utf-8'), '~'*len(token))
-    print("Doctr, running command:", command)
+    print(blue(command))
     sys.stdout.flush()
 
     if token:

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -17,6 +17,12 @@ from cryptography.fernet import Fernet
 
 DOCTR_WORKING_BRANCH = '__doctr_working_branch'
 
+def red(text):
+    return "\033[31m%s\033[0m" % text
+
+def blue(text):
+    return "\033[34m%s\033[0m" % text
+
 def decrypt_file(file, key):
     """
     Decrypts the file ``file``.

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -89,7 +89,8 @@ def run_command_hiding_token(args, token, shell=False):
     else:
         command = args
     command = command.replace(token.decode('utf-8'), '~'*len(token))
-    print(command)
+    print("Doctr, running command:", command)
+    sys.stdout.flush()
 
     if token:
         stdout = stderr = subprocess.PIPE


### PR DESCRIPTION
This changes the API of run_command_hiding_token to only return the
returncode, and always print the output.

This change is done so that the command output in Travis appears in order.
Unfortunately, I don't know how to do this properly when there is a token, but
that's not a common use-case.