### PR TITLE
Make --command run in the deploy branch again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ script:
       cd ..;
       python -m doctr deploy --sync .;
       python -m doctr deploy --sync --gh-pages-docs docs;
-      python -m doctr deploy --sync --no-require-master  --built-docs docs/_build/html "docs-$TRAVIS_BRANCH";
+      python -m doctr deploy --sync --no-require-master  --built-docs docs/_build/html "docs-$TRAVIS_BRANCH" --command "echo test && ls && touch docs-$TRAVIS_BRANCH/test-file && git add docs-$TRAVIS_BRANCH/test-file"
       echo `date` >> test
-      python -m doctr deploy --no-require-master  --command "echo test; ls; touch docs/_build/html/test" docs;
+      python -m doctr deploy --no-require-master docs;
       # Test syncing a tracked file with a change
       python -m doctr deploy --sync stash-test --built-docs test;
       python -m doctr deploy --deploy-repo drdoctr/drdoctr.github.io docs;

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,18 @@
  Doctr Changelog
 =================
 
+1.6.1 (2017-09-27)
+==================
+
+Minor Changes
+-------------
+
+- Revert the change to ``--command`` from 1.6.0 that makes it run on the
+  original branch. If you want to run a command on the original branch, just
+  run it before running doctr. ``--command`` now runs on the deploy branch, as
+  it did before. This does not revert the other change to ``--command`` from
+  1.6.0 (running with ``shell=True``). (:issue:`259`)
+
 1.6.0 (2017-09-26)
 ==================
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -146,8 +146,9 @@ options available.
         deploy the docs to. By default, it deploys to the repo Doctr is run from.""")
     deploy_parser_add_argument('--no-require-master', dest='require_master', action='store_false',
         default=True, help="""Allow docs to be pushed from a branch other than master""")
-    deploy_parser_add_argument('--command', default=None, help="""Command to
-        be run before committing and pushing. If the command creates
+    deploy_parser_add_argument('--command', default=None,
+        help="""Command to be run before committing and pushing. This command
+        will be run from the deploy repository/branch. If the command creates
         additional files that should be deployed, they should be added to the
         index.""")
     deploy_parser_add_argument('--no-sync', dest='sync', action='store_false',
@@ -261,9 +262,6 @@ def deploy(args, parser):
                                      full_key_path=args.key_path,
                                      branch_whitelist=branch_whitelist)
 
-        if args.command:
-            run(args.command, shell=True)
-
         if args.sync:
             built_docs = args.built_docs or find_sphinx_build_dir()
             if args.temp_dir:
@@ -283,6 +281,9 @@ def deploy(args, parser):
 
         else:
             added, removed = [], []
+
+        if args.command:
+            run(args.command, shell=True)
 
         changes = commit_docs(added=added, removed=removed)
         if changes:


### PR DESCRIPTION
This reverts a regression in the 1.6 release, which made --command run from
the main branch. This is less useful, since you can just run a command before
running doctr if you want to run something in the deploy branch. Running in
the deploy branch is what's needed (e.g., SymPy's docs run a script in the
docs repo that modifies the html files before committing).

I changed the test in .travis.yml to run in the branch build, which adds a
file to the branch deploy directory (since adding a file to the index from
--command to deploy it is supposed to a supported way to sync extra files).

See discussion at https://github.com/drdoctr/doctr/pull/192. 