### PR TITLE
Fix typo in main.py

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -416,7 +416,7 @@ def configure(args, parser):
           - set -e
           - # Command to build your docs
           - pip install doctr
-          - doctr deploy{options} <target-directory>
+          - doctr deploy {options} <target-directory>
 
         env:
           global:


### PR DESCRIPTION
Missing space causes the printed command (to be copy-pasted) to be invalid.