### PR TITLE
Add support for multiple deploy key and GitHub Wiki

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -131,8 +131,9 @@ options available.
     deploy_parser_add_argument('--token', action='store_true', default=False,
         help="""Push to GitHub using a personal access token. Use this if you
         used 'doctr configure --token'.""")
-    deploy_parser_add_argument('--key-path', default='github_deploy_key.enc',
-        help="""Path of the encrypted GitHub deploy key. The default is %(default)r.""")
+    deploy_parser_add_argument('--key-path', default=None,
+        help="""Path of the encrypted GitHub deploy key. The default is github_deploy_key_
+        + deploy respository name + .enc.""")
     deploy_parser_add_argument('--built-docs', default=None,
         help="""Location of the built html documentation to be deployed to gh-pages. If not
         specified, Doctr will try to automatically detect build location
@@ -185,9 +186,9 @@ options available.
         dest="upload_key", help="""Don't automatically upload the deploy key to GitHub. If you select this
         option, you will not be prompted for your GitHub credentials, so this option is not compatible with
         private repositories.""")
-    configure_parser.add_argument('--key-path', default='github_deploy_key',
-        help="""Path to save the encrypted GitHub deploy key. The default is %(default)r.
-    The .enc extension is added to the file automatically.""")
+    configure_parser.add_argument('--key-path', default=None,
+        help="""Path to save the encrypted GitHub deploy key. The default is github_deploy_key_
+        + deploy respository name. The .enc extension is added to the file automatically.""")
 
     return parser
 
@@ -207,6 +208,22 @@ def get_config():
     if not isinstance(config, dict):
         raise ValueError('config is not a dict: {}'.format(config))
     return config
+
+def get_deploy_key_repo(deploy_repo, key_path, key_ext=''):
+    """
+    Return (repository of which deploy key is used, environment variable to store
+    the encryption key of deploy key, path of deploy key file)
+    """
+    # deploy key of the original repo has write access to the wiki
+    deploy_key_repo = deploy_repo[:-5] if deploy_repo.endswith('.wiki') else deploy_repo
+
+    # Automatically determine environment variable and key file name from deploy repo name
+    # Special characters are substituted with a hyphen(-) by GitHub
+    snake_case_name = deploy_key_repo.replace('-', '_').replace('.', '_').replace('/', '_').lower()
+    env_name = 'DOCTR_DEPLOY_KEY_' + snake_case_name.upper()
+    key_path = key_path or 'github_deploy_key_' + snake_case_name + key_ext
+
+    return (deploy_key_repo, env_name, key_path)
 
 def process_args(parser):
     args = parser.parse_args()
@@ -252,6 +269,8 @@ def deploy(args, parser):
     else:
         deploy_branch = 'master' if deploy_repo.endswith(('.github.io', '.github.com', '.wiki')) else 'gh-pages'
 
+    _, env_name, key_path = get_deploy_key_repo(deploy_repo, args.key_path, key_ext='.enc')
+
     current_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
     try:
         branch_whitelist = {'master'} if args.require_master else set(get_travis_branch())
@@ -259,8 +278,8 @@ def deploy(args, parser):
 
         canpush = setup_GitHub_push(deploy_repo, deploy_branch=deploy_branch,
                                      auth_type='token' if args.token else 'deploy_key',
-                                     full_key_path=args.key_path,
-                                     branch_whitelist=branch_whitelist)
+                                     full_key_path=key_path,
+                                     branch_whitelist=branch_whitelist, env_name=env_name)
 
         if args.sync:
             built_docs = args.built_docs or find_sphinx_build_dir()
@@ -369,11 +388,13 @@ def configure(args, parser):
 
         print(header)
     else:
-        # deploy key of the original repo has write access to the wiki
-        deploy_key_repo = deploy_repo[:-5] if deploy_repo.endswith('.wiki') else deploy_repo
-        ssh_key = generate_ssh_key("doctr deploy key for {deploy_repo}".format(deploy_repo=deploy_key_repo), keypath=args.key_path)
-        key = encrypt_file(args.key_path, delete=True)
-        encrypted_variable = encrypt_variable(b"DOCTR_DEPLOY_ENCRYPTION_KEY=" + key, build_repo=build_repo, is_private=is_private, **login_kwargs)
+        deploy_key_repo, env_name, key_path = get_deploy_key_repo(deploy_repo, args.key_path)
+
+        ssh_key = generate_ssh_key("doctr deploy key for {deploy_repo}".format(
+            deploy_repo=deploy_key_repo), keypath=key_path)
+        key = encrypt_file(key_path, delete=True)
+        encrypted_variable = encrypt_variable(env_name.encode('utf-8') + b"=" + key,
+            build_repo=build_repo, is_private=is_private, **login_kwargs)
 
         deploy_keys_url = 'https://github.com/{deploy_repo}/settings/keys'.format(deploy_repo=deploy_key_repo)
 
@@ -385,7 +406,7 @@ def configure(args, parser):
             The deploy key has been added for {deploy_repo}.
 
             You can go to {deploy_keys_url} to revoke the deploy key.\
-            """.format(deploy_repo=deploy_key_repo, deploy_keys_url=deploy_keys_url, keypath=args.key_path)))
+            """.format(deploy_repo=deploy_key_repo, deploy_keys_url=deploy_keys_url, keypath=key_path)))
             print(header)
         else:
             print(header)
@@ -403,11 +424,11 @@ def configure(args, parser):
 
             git add {keypath}.enc
 
-        """.format(keypath=args.key_path, N=N)))
+        """.format(keypath=key_path, N=N)))
 
     options = '--built-docs path/to/built/html/'
-    if args.key_path != 'github_deploy_key':
-        options += ' --key-path {keypath}.enc'.format(keypath=args.key_path)
+    if args.key_path:
+        options += ' --key-path {keypath}.enc'.format(keypath=key_path)
     if deploy_repo != build_repo:
         options += ' --deploy-repo {deploy_repo}'.format(deploy_repo=deploy_repo)
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -132,8 +132,8 @@ options available.
         help="""Push to GitHub using a personal access token. Use this if you
         used 'doctr configure --token'.""")
     deploy_parser_add_argument('--key-path', default=None,
-        help="""Path of the encrypted GitHub deploy key. The default is github_deploy_key_
-        + deploy respository name + .enc.""")
+        help="""Path of the encrypted GitHub deploy key. The default is github_deploy_key_+
+        deploy respository name + .enc.""")
     deploy_parser_add_argument('--built-docs', default=None,
         help="""Location of the built html documentation to be deployed to gh-pages. If not
         specified, Doctr will try to automatically detect build location
@@ -187,8 +187,8 @@ options available.
         option, you will not be prompted for your GitHub credentials, so this option is not compatible with
         private repositories.""")
     configure_parser.add_argument('--key-path', default=None,
-        help="""Path to save the encrypted GitHub deploy key. The default is github_deploy_key_
-        + deploy respository name. The .enc extension is added to the file automatically.""")
+        help="""Path to save the encrypted GitHub deploy key. The default is github_deploy_key_+
+        deploy respository name. The .enc extension is added to the file automatically.""")
 
     return parser
 

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -22,10 +22,13 @@ def test_github_bad_user():
 def test_github_bad_repo():
     with raises(RuntimeError):
         check_repo_exists('drdoctr/---', headers=HEADERS)
+    with raises(RuntimeError):
+        check_repo_exists('drdoctr/---.wiki', headers=HEADERS)
 
 @pytest.mark.skipif(not TEST_TOKEN, reason="No API token present")
 def test_github_repo_exists():
     assert not check_repo_exists('drdoctr/doctr', headers=HEADERS)
+    assert not check_repo_exists('drdoctr/doctr.wiki', headers=HEADERS)
 
 @pytest.mark.skipif(not TEST_TOKEN, reason="No API token present")
 def test_github_invalid_repo():


### PR DESCRIPTION
* Add support for multiple deploy key encryption key. Automatically determines deploy key encryption key environment variable name and filename from deploy key repo name: Fixes #242.
* Add support for deployment to GitHub wiki: Fixes #275.