### PR TITLE
Print helpful error message when repository check fails

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -337,8 +337,8 @@ def configure(args, parser):
             is_private = check_repo_exists(build_repo, service='github', **login_kwargs)
             check_repo_exists(build_repo, service='travis')
             get_build_repo = True
-        except RuntimeError:
-            print('\n{:-^{}}\n'.format('Invalid repo or user. Please try again.', 70))
+        except RuntimeError as e:
+            print('\n{!s:-^{}}\n'.format(e, 70))
 
     get_deploy_repo = False
     while not get_deploy_repo:
@@ -351,8 +351,8 @@ def configure(args, parser):
                 check_repo_exists(deploy_repo, service='github', **login_kwargs)
 
             get_deploy_repo = True
-        except RuntimeError:
-            print('\n{:-^{}}\n'.format('Invalid repo or user. Please try again.', 70))
+        except RuntimeError as e:
+            print('\n{!s:-^{}}\n'.format(e, 70))
 
     N = IncrementingInt(1)
 

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -248,9 +248,9 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
     r = requests.get(REPO_URL.format(user=user, repo=repo), auth=auth, headers=headers)
 
     if r.status_code == requests.codes.not_found:
-        raise RuntimeError('"{user}/{repo}" not found on {service}. Exiting'.format(user=user,
-                                                                                    repo=repo,
-                                                                                    service=service))
+        raise RuntimeError('"{user}/{repo}" not found on {service}'.format(user=user,
+                                                                           repo=repo,
+                                                                           service=service))
 
     r.raise_for_status()
 


### PR DESCRIPTION
Print helpful error message(the message of RuntimeError) when repository check(`check_repo_exists`) fails.