### PR TITLE
Add a global table of contents to the docs sidebar

### DIFF
--- a/docs/_templates/sidebarhelp.html
+++ b/docs/_templates/sidebarhelp.html
@@ -1,0 +1,6 @@
+<h3>Need help?</h3>
+
+<p>
+  Open an issue in our <a href="https://github.com/drdoctr/doctr/issues">issue
+  tracker</a>. Issues that are just questions are fine.
+</p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,7 @@ html_theme = 'alabaster'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
+
 html_theme_options = {
     'github_user': 'drdoctr',
     'github_repo': 'doctr',
@@ -134,6 +135,13 @@ html_theme_options = {
     'travis_button': True,
     'show_related': True,
     }
+
+html_sidebars = {
+    '**': ['globaltoc.html', 'sidebarhelp.html',
+           'searchbox.html'],
+    'index': ['localtoc.html', 'globaltoc.html', 'sidebarhelp.html',
+           'searchbox.html'],
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,6 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to the Doctr documentation!
-===================================
 
 .. include:: ../README.rst
 


### PR DESCRIPTION
This fixes https://github.com/drdoctr/doctr/issues/231. If we find a better theme, we can use it, but this is the main thing I wanted. 