### PR TITLE
Add Spyder to project list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,4 +236,6 @@ Projects using Doctr
 
 - `XPD stack <http://xpdacq.github.io/>`_
 
+- `Spyder IDE <https://www.spyder-ide.org/>`_
+
 Are you using Doctr?  Please add your project to the list!


### PR DESCRIPTION
Adds the [Spyder IDE](https://www.spyder-ide.org/) to the project list, which uses ``doctr`` to deploy its [docs](https://docs.spyder-ide.org/).