### PR TITLE
Add support for public repos on travis-ci.com

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -248,7 +248,7 @@ def process_args(parser):
     try:
         return args.func(args, parser)
     except RuntimeError as e:
-        sys.exit("Error: " + e.args[0])
+        sys.exit(red("Error: " + e.args[0]))
 
 def on_travis():
     return os.environ.get("TRAVIS_JOB_NUMBER", '')

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -196,9 +196,14 @@ options available.
         public repositories for the user. This option is not recommended
         unless you are using a separate GitHub user for deploying.""")
     configure_parser.add_argument("--no-upload-key", action="store_false", default=True,
-        dest="upload_key", help="""Don't automatically upload the deploy key to GitHub. If you select this
-        option, you will not be prompted for your GitHub credentials, so this option is not compatible with
-        private repositories.""")
+        dest="upload_key", help="""Don't automatically upload the deploy key to GitHub. To prevent doctr
+        configure from asking for your GitHub credentials, use
+        --no-authenticate.""")
+    configure_parser.add_argument("--no-authenticate", action="store_false",
+        default=True, dest="authenticate", help="""Don't authenticate with GitHub. This option implies --no-upload-key. Note:
+        it is not possible to configure travis-ci.com with this option, only
+        .org (see https://github.com/travis-ci/travis-ci/issues/9954). This
+        option is also not compatible with private repositories.""")
     configure_parser.add_argument('--key-path', default=None,
         help="""Path to save the encrypted GitHub deploy key. The default is github_deploy_key_+
         deploy respository name. The .enc extension is added to the file automatically.""")
@@ -370,6 +375,8 @@ def configure(args, parser):
         parser.error(red("doctr appears to be running on Travis. Use "
             "doctr configure --force to run anyway."))
 
+    if not args.authenticate:
+        args.upload_key = False
 
     print(green(dedent("""\
     Welcome to Doctr.
@@ -379,7 +386,8 @@ def configure(args, parser):
     """)))
 
     login_kwargs = {}
-    if args.upload_key:
+
+    if args.authenticate:
         while not login_kwargs:
             try:
                 login_kwargs = GitHub_login()

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -397,7 +397,7 @@ def configure(args, parser):
             else:
                 build_repo = input("What repo do you want to build the docs for (org/reponame, like 'drdoctr/doctr')? ")
             is_private = check_repo_exists(build_repo, service='github', **login_kwargs)
-            check_repo_exists(build_repo, service='travis')
+            is_private = check_repo_exists(build_repo, service='travis', ask=True) or is_private
             get_build_repo = True
         except RuntimeError as e:
             print(red('\n{!s:-^{}}\n'.format(e, 70)))
@@ -423,7 +423,7 @@ def configure(args, parser):
     if args.token:
         token = generate_GitHub_token(**login_kwargs)['token']
         encrypted_variable = encrypt_variable("GH_TOKEN={token}".format(token=token).encode('utf-8'),
-            build_repo=build_repo, dotcom=True, **login_kwargs)
+            build_repo=build_repo, is_private=is_private, **login_kwargs)
         print(dedent("""
         A personal access token for doctr has been created.
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -406,8 +406,15 @@ def configure(args, parser):
                     build_repo = default_repo
             else:
                 build_repo = input("What repo do you want to build the docs for (org/reponame, like 'drdoctr/doctr')? ")
-            is_private = check_repo_exists(build_repo, service='github', **login_kwargs)
+            is_private = check_repo_exists(build_repo, service='github',
+    **login_kwargs)
+            if is_private and not args.authenticate:
+                sys.exit(red("--no-authenticate is not supported for private repositories."))
+
             is_private = check_repo_exists(build_repo, service='travis', ask=True) or is_private
+            if is_private and not args.authenticate:
+                sys.exit(red("--no-authenticate is not supported for travis-ci.com. See https://github.com/travis-ci/travis-ci/issues/9954."))
+
             get_build_repo = True
         except GitHubError:
             raise

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -39,7 +39,7 @@ from .local import (generate_GitHub_token, encrypt_variable, encrypt_to_file,
     GitHub_login, guess_github_repo, AuthenticationFailed)
 from .travis import (setup_GitHub_push, commit_docs, push_docs,
     get_current_repo, sync_from_log, find_sphinx_build_dir, run,
-    get_travis_branch, copy_to_tmp, checkout_deploy_branch)
+    get_travis_branch, copy_to_tmp, checkout_deploy_branch, travis_tld)
 
 from .common import red, green, blue, bold_black, BOLD_BLACK, BOLD_MAGENTA, RESET
 
@@ -257,6 +257,8 @@ def deploy(args, parser):
     if not args.force and not on_travis():
         parser.error("doctr does not appear to be running on Travis. Use "
                      "doctr deploy <target-dir> --force to run anyway.")
+
+    print("We seem to be running on travis-ci{tld}".format(travis_tld))
 
     config = get_config()
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -391,7 +391,7 @@ def configure(args, parser):
     while not get_build_repo:
         try:
             if default_repo:
-                build_repo = input("What repo do you want to build the docs for [{default_repo}]? ".format(default_repo=blue(default_repo)))
+                build_repo = input("What repo do you want to build the docs for? [{default_repo}] ".format(default_repo=blue(default_repo)))
                 if not build_repo:
                     build_repo = default_repo
             else:

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -258,7 +258,7 @@ def deploy(args, parser):
         parser.error("doctr does not appear to be running on Travis. Use "
                      "doctr deploy <target-dir> --force to run anyway.")
 
-    print("We seem to be running on travis-ci{tld}".format(travis_tld))
+    print("We seem to be running on travis-ci{tld}".format(tld=travis_tld()))
 
     config = get_config()
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -423,7 +423,7 @@ def configure(args, parser):
     if args.token:
         token = generate_GitHub_token(**login_kwargs)['token']
         encrypted_variable = encrypt_variable("GH_TOKEN={token}".format(token=token).encode('utf-8'),
-            build_repo=build_repo, is_private=is_private, **login_kwargs)
+            build_repo=build_repo, dotcom=True, **login_kwargs)
         print(dedent("""
         A personal access token for doctr has been created.
 

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -39,7 +39,7 @@ from .local import (generate_GitHub_token, encrypt_variable, encrypt_to_file,
     GitHub_login, guess_github_repo, AuthenticationFailed, GitHubError)
 from .travis import (setup_GitHub_push, commit_docs, push_docs,
     get_current_repo, sync_from_log, find_sphinx_build_dir, run,
-    get_travis_branch, copy_to_tmp, checkout_deploy_branch, travis_tld)
+    get_travis_branch, copy_to_tmp, checkout_deploy_branch)
 
 from .common import red, green, blue, bold_black, BOLD_BLACK, BOLD_MAGENTA, RESET
 
@@ -259,8 +259,6 @@ def deploy(args, parser):
     if not args.force and not on_travis():
         parser.error("doctr does not appear to be running on Travis. Use "
                      "doctr deploy <target-dir> --force to run anyway.")
-
-    print("We seem to be running on travis-ci{tld}".format(tld=travis_tld()))
 
     config = get_config()
 

--- a/doctr/common.py
+++ b/doctr/common.py
@@ -2,6 +2,15 @@
 Code used for both Travis and local (deploy and configure)
 """
 
+# Color guide
+#
+# - red: Error and warning messages
+# - green: Welcome messages (use sparingly)
+# - blue: Default values
+# - bold_magenta: Action items
+# - bold_black: Parts of code to be run or copied that should be modified
+
+
 def red(text):
     return "\033[31m%s\033[0m" % text
 

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -70,6 +70,7 @@ def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False,
         else:
             res = requests.get('https://api.travis-ci.org/repos/{build_repo}/key'.format(build_repo=build_repo), headers=headersv2)
             public_key = res.json()['key']
+
         if res.status_code == requests.codes.not_found:
             raise RuntimeError('Could not find requested repo on Travis.  Is Travis enabled?')
         res.raise_for_status()

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -379,7 +379,7 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None,
                             r = r_org
                             service = 'travis-ci.org'
                             break
-                        elif preferred in ['c', 'com', '.com', 'travis-ci.com']:
+                        elif preferred in ['c', 'com', '.com', 'travis-ci.com', '']:
                             service = 'travis-ci.com'
                             break
                         else:

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -237,8 +237,10 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
 
     Raises ``RuntimeError`` if the repo is not valid.
 
-    Returns whether or not the repo is on travis-ci.com (which requires
-    authorization to access, regardless of whether or not it is private)
+    Returns whether or not the repo requires authorization to access. Private
+    repos require authorization, as to repos on travis-ci.com, regardless of
+    whether or not it is private.
+
     """
     headers = headers or {}
     if deploy_repo.count("/") != 1:

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -260,10 +260,10 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
     user, repo = deploy_repo.split('/')
     if service == 'github':
         REPO_URL = 'https://api.github.com/repos/{user}/{repo}'
-    elif service == 'travis':
+    elif service == 'travis' or service == 'travis.com':
         REPO_URL = 'https://api.travis-ci.com/repo/{user}%2F{repo}'
         headers['Travis-API-Version'] = '3'
-    elif service == 'travis-org':
+    elif service == 'travis.org':
         REPO_URL = 'https://api.travis-ci.org/repo/{user}%2F{repo}'
         headers['Travis-API-Version'] = '3'
     else:
@@ -285,6 +285,9 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
                                                                            repo=repo,
                                                                            service=service))
 
+    if service == 'travis':
+        service = 'travis.com'
+
     r.raise_for_status()
     private = r.json().get('private', False)
 
@@ -296,7 +299,7 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
             raise RuntimeError('Wiki not found. Please create a wiki')
         return False
 
-    return private or (service == 'travis')
+    return private or (service == 'travis.com')
 
 GIT_URL = re.compile(r'(?:git@|https://|git://)github\.com[:/](.*?)(?:\.git)?')
 

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -75,12 +75,14 @@ def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False,
             res = requests.get('https://api.travis-ci.org/repos/{build_repo}/key'.format(build_repo=build_repo), headers=headersv2)
             public_key = res.json()['key']
 
-        if res.status_code == requests.codes.not_found:
-            raise RuntimeError('Could not find requested repo on Travis.  Is Travis enabled?')
-        res.raise_for_status()
-        # Remove temporary GH token
-        if is_private:
-            delete_GitHub_token(token_id, **login_kwargs)
+        try:
+            if res.status_code == requests.codes.not_found:
+                raise RuntimeError('Could not find requested repo on Travis.  Is Travis enabled?')
+            res.raise_for_status()
+        finally:
+            # Remove temporary GH token
+            if is_private:
+                delete_GitHub_token(token_id, **login_kwargs)
 
     public_key = public_key.replace("RSA PUBLIC KEY", "PUBLIC KEY").encode('utf-8')
     key = serialization.load_pem_public_key(public_key, backend=default_backend())

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -55,6 +55,8 @@ def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False,
         headersv2 = {**_headers, **APIv2}
         headersv3 = {**_headers, **APIv3}
         if is_private:
+            print("I need to generate a temporary token with GitHub to authenticate with Travis.")
+            print("It will be deleted immediately. If you still see it after this at https://github.com/settings/tokens after please delete it manually.")
             # /auth/github doesn't seem to exist in the Travis API v3.
             tok_dict = generate_GitHub_token(scopes=["read:org", "user:email", "repo"],
                                              note="temporary token for doctr to auth against travis (delete me)",

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -58,8 +58,8 @@ def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False,
         token_id = None
         try:
             if is_private:
-                print("I need to generate a temporary token with GitHub to authenticate with Travis.")
-                print("It will be deleted immediately. If you still see it after this at https://github.com/settings/tokens after please delete it manually.")
+                print(green("I need to generate a temporary token with GitHub to authenticate with Travis. You may get a warning email from GitHub about this."))
+                print(green("It will be deleted immediately. If you still see it after this at https://github.com/settings/tokens after please delete it manually."))
                 # /auth/github doesn't seem to exist in the Travis API v3.
                 tok_dict = generate_GitHub_token(scopes=["read:org", "user:email", "repo"],
                                                  note="temporary token for doctr to auth against travis (delete me)",

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -260,10 +260,10 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
     user, repo = deploy_repo.split('/')
     if service == 'github':
         REPO_URL = 'https://api.github.com/repos/{user}/{repo}'
-    elif service == 'travis' or service == 'travis.com':
+    elif service == 'travis' or service == 'travis-ci.com':
         REPO_URL = 'https://api.travis-ci.com/repo/{user}%2F{repo}'
         headers['Travis-API-Version'] = '3'
-    elif service == 'travis.org':
+    elif service == 'travis-ci.org':
         REPO_URL = 'https://api.travis-ci.org/repo/{user}%2F{repo}'
         headers['Travis-API-Version'] = '3'
     else:
@@ -279,14 +279,14 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
 
     if r.status_code == requests.codes.not_found:
         if service == 'travis':
-            return check_repo_exists(deploy_repo, service='travis-org',
+            return check_repo_exists(deploy_repo, service='travis-ci.org',
                                      auth=auth, headers=headers)
         raise RuntimeError('"{user}/{repo}" not found on {service}'.format(user=user,
                                                                            repo=repo,
                                                                            service=service))
 
     if service == 'travis':
-        service = 'travis.com'
+        service = 'travis-ci.com'
 
     r.raise_for_status()
     private = r.json().get('private', False)
@@ -299,7 +299,7 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None, headers=None)
             raise RuntimeError('Wiki not found. Please create a wiki')
         return False
 
-    return private or (service == 'travis.com')
+    return private or (service == 'travis-ci.com')
 
 GIT_URL = re.compile(r'(?:git@|https://|git://)github\.com[:/](.*?)(?:\.git)?')
 

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -65,7 +65,7 @@ def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False,
             res.raise_for_status()
             headersv3['Authorization'] = 'token {}'.format(res.json()['access_token'])
             res = requests.get('https://api.travis-ci.com/repo/{build_repo}/key_pair/generated'.format(build_repo=urllib.parse.quote(build_repo,
-            safe=''), headers=headersv3))
+                safe=''), headers=headersv3))
             public_key = res.json()['public_key']
         else:
             res = requests.get('https://api.travis-ci.org/repos/{build_repo}/key'.format(build_repo=build_repo), headers=headersv2)
@@ -274,7 +274,7 @@ def check_repo_exists(deploy_repo, service='github', *, auth=None,
         REPO_URL = 'https://api.travis-ci.org/repo/{user}%2F{repo}'
         headers['Travis-API-Version'] = '3'
     else:
-        raise RuntimeError('Invalid service specified for repo check (neither "travis" nor "github")')
+        raise RuntimeError('Invalid service specified for repo check (should be one of {"github", "travis", "travis-ci.com", "travis-ci.org"}')
 
     wiki = False
     if repo.endswith('.wiki') and service == 'github':

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 
-from .common import red, blue
+from .common import red, blue, green
 
 def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False, **login_kwargs):
     """

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -67,7 +67,7 @@ def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False,
             res.raise_for_status()
             headersv3['Authorization'] = 'token {}'.format(res.json()['access_token'])
             res = requests.get('https://api.travis-ci.com/repo/{build_repo}/key_pair/generated'.format(build_repo=urllib.parse.quote(build_repo,
-                safe=''), headers=headersv3))
+                safe='')), headers=headersv3)
             public_key = res.json()['public_key']
         else:
             res = requests.get('https://api.travis-ci.org/repos/{build_repo}/key'.format(build_repo=build_repo), headers=headersv2)

--- a/doctr/local.py
+++ b/doctr/local.py
@@ -68,6 +68,8 @@ def encrypt_variable(variable, build_repo, *, public_key=None, is_private=False,
             headersv3['Authorization'] = 'token {}'.format(res.json()['access_token'])
             res = requests.get('https://api.travis-ci.com/repo/{build_repo}/key_pair/generated'.format(build_repo=urllib.parse.quote(build_repo,
                 safe='')), headers=headersv3)
+            if res.json().get('file') == 'not found':
+                raise RuntimeError("Could not find the Travis public key for %s" % build_repo)
             public_key = res.json()['public_key']
         else:
             res = requests.get('https://api.travis-ci.org/repos/{build_repo}/key'.format(build_repo=build_repo), headers=headersv2)

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -49,8 +49,8 @@ def test_travis_bad_repo():
         check_repo_exists('drdoctr/DoCtR', service='travis')
 
 def test_travis_repo_exists():
-    assert not check_repo_exists('drdoctr/doctr', service='travis.org')
-    assert check_repo_exists('drdoctr/doctr', service='travis.com')
+    assert not check_repo_exists('drdoctr/doctr', service='travis-ci.org')
+    assert check_repo_exists('drdoctr/doctr', service='travis-ci.com')
     assert check_repo_exists('drdoctr/doctr', service='travis')
 
 def test_GIT_URL():

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -49,7 +49,9 @@ def test_travis_bad_repo():
         check_repo_exists('drdoctr/DoCtR', service='travis')
 
 def test_travis_repo_exists():
-    assert not check_repo_exists('drdoctr/doctr', service='travis')
+    assert not check_repo_exists('drdoctr/doctr', service='travis.org')
+    assert check_repo_exists('drdoctr/doctr', service='travis.com')
+    assert check_repo_exists('drdoctr/doctr', service='travis')
 
 def test_GIT_URL():
     for url in [

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -48,6 +48,8 @@ def test_travis_bad_repo():
         # Travis is case-sensitive
         check_repo_exists('drdoctr/DoCtR', service='travis')
 
+# This test may need to be adjusted as travis-ci.org gets merged into
+# travis-ci.com. Currently drdoctr/doctr is enabled on both.
 def test_travis_repo_exists():
     assert not check_repo_exists('drdoctr/doctr', service='travis-ci.org')
     assert check_repo_exists('drdoctr/doctr', service='travis-ci.com')

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 
 from cryptography.fernet import Fernet
+import requests
 
 from .common import red, blue
 DOCTR_WORKING_BRANCH = '__doctr_working_branch'
@@ -575,3 +576,17 @@ def determine_push_rights(*, branch_whitelist, TRAVIS_BRANCH,
         canpush = False
 
     return canpush
+
+def travis_tld():
+    """
+    Determines if the job is being run on travis-ci.com or travis-ci.org
+
+    Returns the tld ('.com' or '.org'). For maximum compatibility, if the tld
+    cannot be determined, it returns '.org'.
+    """
+    # See
+    # https://github.com/travis-ci/travis-ci/issues/7552#issuecomment-416443383.
+    # A request on each domain will return 200 on that domain and 401 on the
+    # other.
+    r = requests.get('https://api.travis-ci.com/jobs')
+    return '.com' if r.status_code == 200 else '.org'

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -588,5 +588,8 @@ def travis_tld():
     # https://github.com/travis-ci/travis-ci/issues/7552#issuecomment-416443383.
     # A request on each domain will return 200 on that domain and 401 on the
     # other.
-    r = requests.get('https://api.travis-ci.com/jobs')
-    return '.com' if r.status_code == 200 else '.org'
+    rcom = requests.get('https://api.travis-ci.com/jobs')
+    rorg = requests.get('https://api.travis-ci.org/jobs')
+    print('travis-ci.com status code', rcom.status_code)
+    print('travis-ci.org status code', rorg.status_code)
+    return '.com' if rorg.status_code == 200 else '.org'

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -14,7 +14,6 @@ import tempfile
 import time
 
 from cryptography.fernet import Fernet
-import requests
 
 from .common import red, blue
 DOCTR_WORKING_BRANCH = '__doctr_working_branch'
@@ -471,7 +470,7 @@ def commit_docs(*, added, removed):
     TRAVIS_BRANCH = os.environ.get("TRAVIS_BRANCH", "<unknown>")
     TRAVIS_COMMIT = os.environ.get("TRAVIS_COMMIT", "<unknown>")
     TRAVIS_REPO_SLUG = os.environ.get("TRAVIS_REPO_SLUG", "<unknown>")
-    TRAVIS_JOB_ID = os.environ.get("TRAVIS_JOB_ID", "")
+    TRAVIS_JOB_WEB_URL = os.environ.get("TRAVIS_JOB_WEB_URL", "<unknown>")
     TRAVIS_TAG = os.environ.get("TRAVIS_TAG", "")
     branch = "tag" if TRAVIS_TAG else "branch"
 
@@ -491,7 +490,7 @@ The docs were built from the {branch} '{TRAVIS_BRANCH}' against the commit
 {TRAVIS_COMMIT}.
 
 The Travis build that generated this commit is at
-https://travis-ci.org/{TRAVIS_REPO_SLUG}/jobs/{TRAVIS_JOB_ID}.
+{TRAVIS_JOB_WEB_URL}.
 
 The doctr command that was run is
 
@@ -502,7 +501,7 @@ The doctr command that was run is
     TRAVIS_BRANCH=TRAVIS_BRANCH,
     TRAVIS_COMMIT=TRAVIS_COMMIT,
     TRAVIS_REPO_SLUG=TRAVIS_REPO_SLUG,
-    TRAVIS_JOB_ID=TRAVIS_JOB_ID,
+    TRAVIS_JOB_WEB_URL=TRAVIS_JOB_WEB_URL,
     DOCTR_COMMAND=DOCTR_COMMAND,
     )
 
@@ -577,20 +576,3 @@ def determine_push_rights(*, branch_whitelist, TRAVIS_BRANCH,
         canpush = False
 
     return canpush
-
-def travis_tld():
-    """
-    Determines if the job is being run on travis-ci.com or travis-ci.org
-
-    Returns the tld ('.com' or '.org'). For maximum compatibility, if the tld
-    cannot be determined, it returns '.org'.
-    """
-    # See
-    # https://github.com/travis-ci/travis-ci/issues/7552#issuecomment-416443383.
-    # A request on each domain will return 200 on that domain and 401 on the
-    # other.
-    rcom = requests.get('https://api.travis-ci.com/jobs')
-    rorg = requests.get('https://api.travis-ci.org/jobs')
-    print('travis-ci.com status code', rcom.status_code)
-    print('travis-ci.org status code', rorg.status_code)
-    return '.com' if rorg.status_code == 200 else '.org'


### PR DESCRIPTION
Fixes https://github.com/drdoctr/doctr/issues/309

This is still not fully tested, and I have a few things that need to be fixed (like the url in the commit message). 

I'm unsure if the logic here is correct. <strike>I test travis-ci.org first and then travis-ci.com. The reason is that travis-ci.com always requires authentication, so .org is preferred. However, maybe it should be the other way around, as apparently it's possible to enable both. </strike> 