### PR TITLE
Fix branch-whitelist logic

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -188,7 +188,7 @@ key.
 Using doctr with ``*.github.io`` pages
 ======================================
 
-Github allows users to create pages at the root url of users' or
+Github allows users to create pages at the root URL of users' or
 organizations' http://github.io pages. For example, an organization
 ``coolteam`` can setup a repository at
 ``https://github.com/coolteam/coolteam.github.io`` and the html files in the

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -289,11 +289,11 @@ def deploy(args, parser):
     current_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
     try:
         branch_whitelist = set() if args.require_master else set(get_travis_branch())
-        branch_whitelist.update(set(config.get('branches',set({}))))
+        branch_whitelist.update(set(config.get('branches', set())))
         if args.branch_whitelist is not None:
             branch_whitelist.update(set(args.branch_whitelist))
-            if not args.branch_whitelist:
-                branch_whitelist = {'master'}
+        elif not branch_whitelist:
+            branch_whitelist = {'master'}
 
         canpush = setup_GitHub_push(deploy_repo, deploy_branch=deploy_branch,
                                      auth_type='token' if args.token else 'deploy_key',


### PR DESCRIPTION
When --branch-whitelist is passed with no arguments, (i.e., it's empty), it
should force the whitelist to be empty. Only when it is not passed at all
should it default to {master}.

I haven't tested this yet.

Should fix #329.