### PR TITLE
Don't attempt to push on builds from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
 script:
   - set -e
   - set -x
+  - echo $TRAVIS_SECURE_ENV_VARS
   # Note, the commands below need --sync to actually sync, to override sync: False below. Also, every deploy to the main repo needs to have --key-path deploy_key.enc.
   - |
     if [[ "${DOCS}" == "true" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
 script:
   - set -e
   - set -x
-  - echo $TRAVIS_SECURE_ENV_VARS
   # Note, the commands below need --sync to actually sync, to override sync: False below. Also, every deploy to the main repo needs to have --key-path deploy_key.enc.
   - |
     if [[ "${DOCS}" == "true" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
     fi
   - if [[ "${TESTS}" == "true" ]]; then
       pyflakes doctr;
-      py.test doctr -v;
+      py.test doctr -v -rs;
     fi
 
 doctr:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
       python -m doctr deploy --sync --key-path deploy_key.enc stash-test/ --built-docs test;
       # Test syncing a single file
       echo `date` >> test-file
-      python -m doctr deploy --sync --key-path deploy_key.enc test-file --built-docs test-file;
+      python -m doctr deploy --sync --key-path deploy_key.enc . --built-docs test-file;
       # Test deploy branch creation. Delete the branch gh-pages-testing on drdoctr/doctr whenever you want to test this.
       python -m doctr deploy --sync --key-path deploy_key.enc --no-require-master --deploy-branch gh-pages-testing docs;
       # Test pushing to .github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
     fi
   - if [[ "${TESTS}" == "true" ]]; then
       pyflakes doctr;
-      py.test doctr;
+      py.test doctr -v;
     fi
 
 doctr:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ script:
       python -m doctr deploy --key-path deploy_key.enc --no-require-master docs;
       # Test syncing a tracked file with a change
       python -m doctr deploy --sync --key-path deploy_key.enc stash-test/ --built-docs test;
+      # Test syncing a single file
+      echo `date` >> test-file
+      python -m doctr deploy --sync --key-path deploy_key.enc test-file --built-docs test-file;
       # Test deploy branch creation. Delete the branch gh-pages-testing on drdoctr/doctr whenever you want to test this.
       python -m doctr deploy --sync --key-path deploy_key.enc --no-require-master --deploy-branch gh-pages-testing docs;
       # Test pushing to .github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
       echo `date` >> test
       python -m doctr deploy --key-path deploy_key.enc --no-require-master docs;
       # Test syncing a tracked file with a change
-      python -m doctr deploy --sync --key-path deploy_key.enc stash-test --built-docs test;
+      python -m doctr deploy --sync --key-path deploy_key.enc stash-test/ --built-docs test;
       # Test deploy branch creation. Delete the branch gh-pages-testing on drdoctr/doctr whenever you want to test this.
       python -m doctr deploy --sync --key-path deploy_key.enc --no-require-master --deploy-branch gh-pages-testing docs;
       # Test pushing to .github.io

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -67,7 +67,7 @@ def test_GIT_URL():
 def test_guess_github_repo():
     """
     Only works if run in this repo, and if cloned from origin. For safety,
-    only run on Travis
+    only run on Travis and not run on fork builds.
     """
-    if on_travis():
+    if on_travis() and os.environ.get('TRAVIS_SECURE_ENV_VARS', 'false') == 'true':
         assert guess_github_repo() == 'drdoctr/doctr'

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -64,7 +64,7 @@ def test_GIT_URL():
 
     assert not GIT_URL.fullmatch('https://gitlab.com/drdoctr/doctr.git')
 
-@pytest.mark.skipif(os.environ.get('TRAVIS_SECURE_ENV_VARS', 'false') != 'true', reason="Not run on Travis fork builds")
+@pytest.mark.skipif(os.environ.get('TRAVIS_REPO_SLUG', '') != 'drdoctr/doctr', reason="Not run on Travis fork builds")
 @pytest.mark.skipif(not on_travis(), reason="Not on Travis")
 def test_guess_github_repo():
     """

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -64,10 +64,11 @@ def test_GIT_URL():
 
     assert not GIT_URL.fullmatch('https://gitlab.com/drdoctr/doctr.git')
 
+@pytest.mark.skipif(not on_travis(), reason="Not on Travis")
+@pytest.mark.skipif(os.environ.get('TRAVIS_SECURE_ENV_VARS', 'false') != 'true', reason="Not run on Travis fork builds")
 def test_guess_github_repo():
     """
     Only works if run in this repo, and if cloned from origin. For safety,
     only run on Travis and not run on fork builds.
     """
-    if on_travis() and os.environ.get('TRAVIS_SECURE_ENV_VARS', 'false') == 'true':
-        assert guess_github_repo() == 'drdoctr/doctr'
+    assert guess_github_repo() == 'drdoctr/doctr'

--- a/doctr/tests/test_local.py
+++ b/doctr/tests/test_local.py
@@ -64,8 +64,8 @@ def test_GIT_URL():
 
     assert not GIT_URL.fullmatch('https://gitlab.com/drdoctr/doctr.git')
 
-@pytest.mark.skipif(not on_travis(), reason="Not on Travis")
 @pytest.mark.skipif(os.environ.get('TRAVIS_SECURE_ENV_VARS', 'false') != 'true', reason="Not run on Travis fork builds")
+@pytest.mark.skipif(not on_travis(), reason="Not on Travis")
 def test_guess_github_repo():
     """
     Only works if run in this repo, and if cloned from origin. For safety,

--- a/doctr/tests/test_travis.py
+++ b/doctr/tests/test_travis.py
@@ -221,57 +221,14 @@ def test_sync_from_log(src, dst):
             os.chdir(old_curdir)
 
 
-def test_sync_from_log_file_to_file():
+@pytest.mark.parametrize("dst", ['dst', 'dst/'])
+def test_sync_from_log_file_to_dir(dst):
     with tempfile.TemporaryDirectory() as dir:
         try:
             old_curdir = os.path.abspath(os.curdir)
             os.chdir(dir)
 
-            # src is a file and dst doesn't exist as a directory or end in /,
-            # so should sync to a file called 'dst'
             src = 'file'
-            dst = 'dst'
-
-            with open(src, 'w') as f:
-                f.write('test1')
-
-            # Test that the sync happens
-            added, removed = sync_from_log(src, dst, 'logfile')
-
-            assert added == [
-                'dst',
-                'logfile',
-                ]
-
-            assert removed == []
-
-            # Make sure dst is a file
-            with open(dst) as f:
-                assert f.read() == 'test1'
-
-
-            with open('logfile') as f:
-                assert f.read() == '\n'.join([
-                    dst,
-                    ])
-
-            # Now make sure that the dst is created as a directory if it
-            # ends in /
-
-        finally:
-            os.chdir(old_curdir)
-
-
-def test_sync_from_log_file_to_dir():
-    with tempfile.TemporaryDirectory() as dir:
-        try:
-            old_curdir = os.path.abspath(os.curdir)
-            os.chdir(dir)
-
-            # src is a file but dst ends in / (even though it doesn't exist),
-            # so it should sync to dst/file
-            src = 'file'
-            dst = 'dst/'
 
             with open(src, 'w') as f:
                 f.write('test1')

--- a/doctr/tests/test_travis.py
+++ b/doctr/tests/test_travis.py
@@ -222,45 +222,53 @@ def test_sync_from_log(src, dst):
 
 
 @pytest.mark.parametrize("""branch_whitelist, TRAVIS_BRANCH,
-                         TRAVIS_PULL_REQUEST, TRAVIS_TAG, build_tags,
+                         TRAVIS_PULL_REQUEST, TRAVIS_TAG, fork, build_tags,
                          canpush""",
                          [
 
-                             ('master', 'doctr', 'true', "", False, False),
-                             ('master', 'doctr', 'false', "", False, False),
-                             ('master', 'master', 'true', "", False, False),
-                             ('master', 'master', 'false', "", False, True),
-                             ('doctr', 'doctr', 'True', "", False, False),
-                             ('doctr', 'doctr', 'false', "", False, True),
-                             ('set()', 'doctr', 'false', "", False, False),
+                             ('master', 'doctr', 'true', "", False, False, False),
+                             ('master', 'doctr', 'false', "", False, False, False),
+                             ('master', 'master', 'true', "", False, False, False),
+                             ('master', 'master', 'false', "", False, False, True),
+                             ('doctr', 'doctr', 'True', "", False, False, False),
+                             ('doctr', 'doctr', 'false', "", False, False, True),
+                             ('set()', 'doctr', 'false', "", False, False, False),
 
-                             ('master', 'doctr', 'true', "tagname", False, False),
-                             ('master', 'doctr', 'false', "tagname", False, False),
-                             ('master', 'master', 'true', "tagname", False, False),
-                             ('master', 'master', 'false', "tagname", False, False),
-                             ('doctr', 'doctr', 'True', "tagname", False, False),
-                             ('doctr', 'doctr', 'false', "tagname", False, False),
-                             ('set()', 'doctr', 'false', "tagname", False, False),
+                             ('master', 'doctr', 'true', "tagname", False, False, False),
+                             ('master', 'doctr', 'false', "tagname", False, False, False),
+                             ('master', 'master', 'true', "tagname", False, False, False),
+                             ('master', 'master', 'false', "tagname", False, False, False),
+                             ('doctr', 'doctr', 'True', "tagname", False, False, False),
+                             ('doctr', 'doctr', 'false', "tagname", False, False, False),
+                             ('set()', 'doctr', 'false', "tagname", False, False, False),
 
-                             ('master', 'doctr', 'true', "", True, False),
-                             ('master', 'doctr', 'false', "", True, False),
-                             ('master', 'master', 'true', "", True, False),
-                             ('master', 'master', 'false', "", True, True),
-                             ('doctr', 'doctr', 'True', "", True, False),
-                             ('doctr', 'doctr', 'false', "", True, True),
-                             ('set()', 'doctr', 'false', "", True, False),
+                             ('master', 'doctr', 'true', "", False, True, False),
+                             ('master', 'doctr', 'false', "", False, True, False),
+                             ('master', 'master', 'true', "", False, True, False),
+                             ('master', 'master', 'false', "", False, True, True),
+                             ('doctr', 'doctr', 'True', "", False, True, False),
+                             ('doctr', 'doctr', 'false', "", False, True, True),
+                             ('set()', 'doctr', 'false', "", False, True, False),
 
-                             ('master', 'doctr', 'true', "tagname", True, True),
-                             ('master', 'doctr', 'false', "tagname", True, True),
-                             ('master', 'master', 'true', "tagname", True, True),
-                             ('master', 'master', 'false', "tagname", True, True),
-                             ('doctr', 'doctr', 'True', "tagname", True, True),
-                             ('doctr', 'doctr', 'false', "tagname", True, True),
-                             ('set()', 'doctr', 'false', "tagname", True, True),
+                             ('master', 'doctr', 'true', "tagname", False, True, True),
+                             ('master', 'doctr', 'false', "tagname", False, True, True),
+                             ('master', 'master', 'true', "tagname", False, True, True),
+                             ('master', 'master', 'false', "tagname", False, True, True),
+                             ('doctr', 'doctr', 'True', "tagname", False, True, True),
+                             ('doctr', 'doctr', 'false', "tagname", False, True, True),
+                             ('set()', 'doctr', 'false', "tagname", False, True, True),
+
+                             ('master', 'doctr', 'true', "", True, False, False),
+                             ('master', 'doctr', 'false', "", True, False, False),
+                             ('master', 'master', 'true', "", True, False, False),
+                             ('master', 'master', 'false', "", True, False, False),
+                             ('doctr', 'doctr', 'True', "", True, False, False),
+                             ('doctr', 'doctr', 'false', "", True, False, False),
+                             ('set()', 'doctr', 'false', "", True, False, False),
 
                          ])
 def test_determine_push_rights(branch_whitelist, TRAVIS_BRANCH,
-    TRAVIS_PULL_REQUEST, TRAVIS_TAG, build_tags, canpush, monkeypatch):
+    TRAVIS_PULL_REQUEST, TRAVIS_TAG, build_tags, fork, canpush, monkeypatch):
     branch_whitelist = {branch_whitelist}
 
     assert determine_push_rights(
@@ -268,6 +276,7 @@ def test_determine_push_rights(branch_whitelist, TRAVIS_BRANCH,
         TRAVIS_BRANCH=TRAVIS_BRANCH,
         TRAVIS_PULL_REQUEST=TRAVIS_PULL_REQUEST,
         TRAVIS_TAG=TRAVIS_TAG,
+        fork=fork,
         build_tags=build_tags) == canpush
 
 @pytest.mark.parametrize("src", ["src", "."])

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -221,9 +221,9 @@ def setup_GitHub_push(deploy_repo, *, auth_type='deploy_key',
     REPO_URL = 'https://api.github.com/repos/{slug}'
     r = requests.get(REPO_URL.format(slug=TRAVIS_REPO_SLUG))
     fork = r.json().get('fork', False)
-    if 'fork' not in r.json():
-        r.raise_for_status()
-        raise RuntimeError("fork key not found")
+    # if 'fork' not in r.json():
+    #     r.raise_for_status()
+    #     raise RuntimeError("fork key not found")
 
     canpush = determine_push_rights(
         branch_whitelist=branch_whitelist,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -446,14 +446,26 @@ def sync_from_log(src, dst, log_file, exclude=()):
         files = glob.iglob(join(src, '**'), recursive=True)
     else:
         files = [src]
-        src = os.path.dirname(src) + os.sep
+
+        if dst.endswith(os.sep):
+            os.makedirs(dst, exist_ok=True)
+        elif not isdir(dst) and os.sep not in src:
+            # src is a file and dst doesn't end in / or exist as a directory,
+            # so make it a file
+            shutil.copy2(src, dst)
+            added.append(dst)
+            if dst in removed:
+                removed.remove(dst)
+            files = []
+
+        src = ''
 
     # sorted makes this easier to test
     for f in sorted(files):
         if any(is_subdir(f, os.path.join(src, i)) for i in exclude):
             continue
         new_f = join(dst, f[len(src):])
-        if isdir(f) or f.endswith('/'):
+        if isdir(f) or f.endswith(os.sep):
             os.makedirs(new_f, exist_ok=True)
         else:
             shutil.copy2(f, new_f)

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -459,7 +459,7 @@ def sync_from_log(src, dst, log_file, exclude=()):
                 removed.remove(dst)
             files = []
 
-        src = ''
+        src = os.path.dirname(src) + os.sep if os.path.isabs(src) else ''
 
     # sorted makes this easier to test
     for f in sorted(files):

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -221,9 +221,8 @@ def setup_GitHub_push(deploy_repo, *, auth_type='deploy_key',
     REPO_URL = 'https://api.github.com/repos/{slug}'
     r = requests.get(REPO_URL.format(slug=TRAVIS_REPO_SLUG))
     fork = r.json().get('fork', False)
-    # if 'fork' not in r.json():
-    #     r.raise_for_status()
-    #     raise RuntimeError("fork key not found")
+    if r.status_code == 403:
+        print(red("Warning: GitHub's API rate limits prevented us from detecting if this build is a fork. If it is, doctr will fail with an error like 'DOCTR_DEPLOY_ENCRYPTION_KEY environment variable is not set'. This error can be safely ignored. If this is not a fork build, the error likely indicates you need to run 'doctr configure' again for this repo."))
 
     canpush = determine_push_rights(
         branch_whitelist=branch_whitelist,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -417,6 +417,7 @@ def sync_from_log(src, dst, log_file, exclude=()):
     ``exclude`` may be a list of paths from ``src`` that should be ignored.
     Such paths are neither added nor removed, even if they are in the logfile.
     """
+    print('dst is', dst)
     from os.path import join, exists, isdir
 
     exclude = [os.path.normpath(i) for i in exclude]

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -224,7 +224,7 @@ def setup_GitHub_push(deploy_repo, *, auth_type='deploy_key',
     # Rate limits prevent this check from working every time. By default, we
     # assume it isn't a fork so that things just work on non-fork builds.
     if r.status_code == 403:
-        print(red("Warning: GitHub's API rate limits prevented us from detecting if this build is a fork. If it is, doctr will fail with an error like 'DOCTR_DEPLOY_ENCRYPTION_KEY environment variable is not set'. This error can be safely ignored. If this is not a fork build, you can ignore this warning."))
+        print(red("Warning: GitHub's API rate limits prevented us from detecting if this build is a fork. If it is, doctr will fail with an error like 'DOCTR_DEPLOY_ENCRYPTION_KEY environment variable is not set'. This error can be safely ignored. If this is not a fork build, you can ignore this warning."), file=sys.stderr)
 
     canpush = determine_push_rights(
         branch_whitelist=branch_whitelist,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -466,11 +466,15 @@ def sync_from_log(src, dst, log_file, exclude=()):
         if any(is_subdir(f, os.path.join(src, i)) for i in exclude):
             continue
         new_f = join(dst, f[len(src):])
-        print(src, dst, f, new_f)
+
         if isdir(f) or f.endswith(os.sep):
             os.makedirs(new_f, exist_ok=True)
         else:
-            shutil.copy2(f, new_f)
+            try:
+                shutil.copy2(f, new_f)
+            except:
+                print("DEBUG:", src, dst, f, new_f)
+                raise
             added.append(new_f)
             if new_f in removed:
                 removed.remove(new_f)

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -220,7 +220,7 @@ def setup_GitHub_push(deploy_repo, *, auth_type='deploy_key',
     TRAVIS_REPO_SLUG = os.environ["TRAVIS_REPO_SLUG"]
     REPO_URL = 'https://api.github.com/repos/{slug}'
     r = requests.get(REPO_URL.format(slug=TRAVIS_REPO_SLUG))
-    fork = r.json()['fork']
+    fork = r.json().get('fork', False)
 
     canpush = determine_push_rights(
         branch_whitelist=branch_whitelist,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -417,7 +417,6 @@ def sync_from_log(src, dst, log_file, exclude=()):
     ``exclude`` may be a list of paths from ``src`` that should be ignored.
     Such paths are neither added nor removed, even if they are in the logfile.
     """
-    print('dst is', dst)
     from os.path import join, exists, isdir
 
     exclude = [os.path.normpath(i) for i in exclude]
@@ -466,6 +465,7 @@ def sync_from_log(src, dst, log_file, exclude=()):
         if any(is_subdir(f, os.path.join(src, i)) for i in exclude):
             continue
         new_f = join(dst, f[len(src):])
+        print(src, dst, f, new_f)
         if isdir(f) or f.endswith(os.sep):
             os.makedirs(new_f, exist_ok=True)
         else:

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -224,7 +224,7 @@ def setup_GitHub_push(deploy_repo, *, auth_type='deploy_key',
     # Rate limits prevent this check from working every time. By default, we
     # assume it isn't a fork so that things just work on non-fork builds.
     if r.status_code == 403:
-        print(red("Warning: GitHub's API rate limits prevented us from detecting if this build is a fork. If it is, doctr will fail with an error like 'DOCTR_DEPLOY_ENCRYPTION_KEY environment variable is not set'. This error can be safely ignored. If this is not a fork build, you can ignore this warning."), file=sys.stderr)
+        print(red("Warning: GitHub's API rate limits prevented doctr from detecting if this build is a fork. If it is, doctr will fail with an error like 'DOCTR_DEPLOY_ENCRYPTION_KEY environment variable is not set'. This error can be safely ignored. If this is not a fork build, you can ignore this warning."), file=sys.stderr)
 
     canpush = determine_push_rights(
         branch_whitelist=branch_whitelist,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -453,7 +453,7 @@ def sync_from_log(src, dst, log_file, exclude=()):
         if any(is_subdir(f, os.path.join(src, i)) for i in exclude):
             continue
         new_f = join(dst, f[len(src):])
-        if isdir(f):
+        if isdir(f) or f.endswith('/'):
             os.makedirs(new_f, exist_ok=True)
         else:
             shutil.copy2(f, new_f)

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -447,19 +447,9 @@ def sync_from_log(src, dst, log_file, exclude=()):
         files = glob.iglob(join(src, '**'), recursive=True)
     else:
         files = [src]
+        src = os.path.dirname(src) + os.sep if os.sep in src else ''
 
-        if dst.endswith(os.sep):
-            os.makedirs(dst, exist_ok=True)
-        elif not isdir(dst) and os.sep not in dst:
-            # src is a file and dst doesn't end in / or exist as a directory,
-            # so make it a file
-            shutil.copy2(src, dst)
-            added.append(dst)
-            if dst in removed:
-                removed.remove(dst)
-            files = []
-
-        src = os.path.dirname(src) + os.sep if os.path.isabs(src) else ''
+        os.makedirs(dst, exist_ok=True)
 
     # sorted makes this easier to test
     for f in sorted(files):

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -450,7 +450,7 @@ def sync_from_log(src, dst, log_file, exclude=()):
 
         if dst.endswith(os.sep):
             os.makedirs(dst, exist_ok=True)
-        elif not isdir(dst) and os.sep not in src:
+        elif not isdir(dst) and os.sep not in dst:
             # src is a file and dst doesn't end in / or exist as a directory,
             # so make it a file
             shutil.copy2(src, dst)

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -470,11 +470,7 @@ def sync_from_log(src, dst, log_file, exclude=()):
         if isdir(f) or f.endswith(os.sep):
             os.makedirs(new_f, exist_ok=True)
         else:
-            try:
-                shutil.copy2(f, new_f)
-            except:
-                print("DEBUG:", src, dst, f, new_f, file=sys.stderr)
-                raise
+            shutil.copy2(f, new_f)
             added.append(new_f)
             if new_f in removed:
                 removed.remove(new_f)

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -221,6 +221,9 @@ def setup_GitHub_push(deploy_repo, *, auth_type='deploy_key',
     REPO_URL = 'https://api.github.com/repos/{slug}'
     r = requests.get(REPO_URL.format(slug=TRAVIS_REPO_SLUG))
     fork = r.json().get('fork', False)
+    if 'fork' not in r.json():
+        r.raise_for_status()
+        raise RuntimeError("fork key not found")
 
     canpush = determine_push_rights(
         branch_whitelist=branch_whitelist,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -221,8 +221,10 @@ def setup_GitHub_push(deploy_repo, *, auth_type='deploy_key',
     REPO_URL = 'https://api.github.com/repos/{slug}'
     r = requests.get(REPO_URL.format(slug=TRAVIS_REPO_SLUG))
     fork = r.json().get('fork', False)
+    # Rate limits prevent this check from working every time. By default, we
+    # assume it isn't a fork so that things just work on non-fork builds.
     if r.status_code == 403:
-        print(red("Warning: GitHub's API rate limits prevented us from detecting if this build is a fork. If it is, doctr will fail with an error like 'DOCTR_DEPLOY_ENCRYPTION_KEY environment variable is not set'. This error can be safely ignored. If this is not a fork build, the error likely indicates you need to run 'doctr configure' again for this repo."))
+        print(red("Warning: GitHub's API rate limits prevented us from detecting if this build is a fork. If it is, doctr will fail with an error like 'DOCTR_DEPLOY_ENCRYPTION_KEY environment variable is not set'. This error can be safely ignored. If this is not a fork build, you can ignore this warning."))
 
     canpush = determine_push_rights(
         branch_whitelist=branch_whitelist,

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -473,7 +473,7 @@ def sync_from_log(src, dst, log_file, exclude=()):
             try:
                 shutil.copy2(f, new_f)
             except:
-                print("DEBUG:", src, dst, f, new_f)
+                print("DEBUG:", src, dst, f, new_f, file=sys.stderr)
                 raise
             added.append(new_f)
             if new_f in removed:


### PR DESCRIPTION
Travis does not make encrypted environment variables available to forks, so
doctr should not attempt to push from them.

I have to check this with the GitHub API, so hopefully that doesn't cause issues. 

Fixes #110
Closes #331
Closes #236