### PR TITLE
Increase the number of retries

### DIFF
--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -533,7 +533,7 @@ The doctr command that was run is
 
     return False
 
-def push_docs(deploy_branch='gh-pages', retries=3):
+def push_docs(deploy_branch='gh-pages', retries=5):
     """
     Push the changes to the branch named ``deploy_branch``.
 


### PR DESCRIPTION
The doctr Travis builds are failing because of retry issues.

Only master is failing because most of the pushes only happen on master. So we may need to tweak this a few times to get it working. 