### PR TITLE
TRAVIS_TAG could set canpush without checking all rules

### DIFF
--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -575,10 +575,9 @@ def determine_push_rights(*, branch_whitelist, TRAVIS_BRANCH,
     """
     canpush = True
 
-    if TRAVIS_TAG:
-        if not build_tags:
-            print("The docs are not pushed on tag builds. To push on future tag builds, use --build-tags")
-        return build_tags
+    if TRAVIS_TAG and not build_tags:
+        print("The docs are not pushed on tag builds. To push on future tag builds, use --build-tags")
+        canpush = False
 
     if not any([re.compile(x).match(TRAVIS_BRANCH) for x in branch_whitelist]):
         print("The docs are only pushed to gh-pages from master. To allow pushing from "


### PR DESCRIPTION
If ``$TRAVIS_TAG`` and ``--build-tags`` are set, then we get ``canpush=True`` without checking all rules, e.g. If the repository was a fork, then the push should be prevented.

As an aside, I noticed this edge can while looking at issue #342 (there are legitimate cases where it is reasonable to want to push from a forked repository).
