### PR TITLE
deployment variable in a (secure) environment variable

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -399,6 +399,10 @@ def configure(args, parser):
     if args.token and args.dkenv:
         parser.error("The --token and --dkenv settings are incompatible.")
 
+    if len(args.dkenv.split()) != 1:
+        # Not going to repeat this sanity test in the deploy command:
+        parser.error("The --dkenv setting should be one word only, e.g. DOC_KEY.")
+
     if not args.authenticate:
         args.upload_key = False
 
@@ -531,6 +535,7 @@ def configure(args, parser):
                and add the following as a new key:{RESET}
 
                 {ssh_key}
+
                {BOLD_MAGENTA}Be sure to allow write access for the key.{RESET}
             """.format(ssh_key=public_ssh_key, deploy_keys_url=deploy_keys_url, N=N,
                        BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET)))
@@ -554,15 +559,13 @@ def configure(args, parser):
         key_type = "personal access token"
 
     if args.dkenv:
+        options += ' --dkenv ' + args.dkenv
         print(dedent("""\
         {N}. {BOLD_MAGENTA}Add the following private deployment key to your TravisCI
-        repository settings as environment variable {env_name}:{RESET}
-
-        {private_ssh_key}
-
-        WARNING: Do not otherwise share this private key!
+           repository settings as environment variable {env_name}:{RESET}
         """.format(N=N, BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET,
                    env_name=args.dkenv, private_ssh_key=private_ssh_key)))
+        print(private_ssh_key)
 
     print(dedent("""\
     {N}. {BOLD_MAGENTA}Add these lines to your `.travis.yml` file:{RESET}

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -9,7 +9,8 @@ The doctr command is two commands in one. To use, first run::
 
 on your local machine. This will prompt for your GitHub credentials and the
 name of the repo you want to deploy docs for. This will generate a secure key,
-which you should insert into your .travis.yml.
+which you should insert into your .travis.yml (or set as a secure environment
+variable in your TravisCI repository settings if using the --dkenv option).
 
 Then, on Travis, for the build where you build your docs, add::
 
@@ -134,6 +135,10 @@ options available.
     if we do not appear to be on Travis.""")
     deploy_parser_add_argument('deploy_directory', type=str, nargs='?',
         help="""Directory to deploy the html documentation to on gh-pages.""")
+    deploy_parser_add_argument('--dkenv', type=str, metavar="ENVVAR",
+        help="""Push to GitHub using a deployment key stored in the named
+        environment variable via your TravisCI repository settings.
+        Use this if you used 'doctr configure --dkenv ENVVAR'.""")
     deploy_parser_add_argument('--token', action='store_true', default=False,
         help="""Push to GitHub using a personal access token. Use this if you
         used 'doctr configure --token'.""")
@@ -193,6 +198,11 @@ options available.
     configure_parser.set_defaults(func=configure)
     configure_parser.add_argument('--force', action='store_true', help="""Run the configure command even
     if we appear to be on Travis.""")
+    configure_parser.add_argument('--dkenv', type=str, metavar="ENVVAR",
+        help="""Generate a deployment key to push to GitHub. The public key
+        will be added to your GitHub repository settings. The private key
+        should be added to you TravisCI repository settings as a protected
+        environment variable.""")
     configure_parser.add_argument('--token', action="store_true", default=False,
         help="""Generate a personal access token to push to GitHub. The default is to use a
         deploy key. WARNING: This will grant read/write access to all the

--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -285,6 +285,9 @@ def deploy(args, parser):
 
     config = get_config()
 
+    if args.token and args.dkenv:
+        parser.error("The --token and --dkenv settings are incompatible.")
+
     if args.tmp_dir:
         parser.error("The --tmp-dir flag has been removed (doctr no longer uses a temporary directory when deploying).")
 
@@ -320,10 +323,10 @@ def deploy(args, parser):
 
         canpush = setup_GitHub_push(deploy_repo, deploy_branch=deploy_branch,
                                      auth_type='token' if args.token else 'deploy_key',
-                                     full_key_path=keypath,
+                                     full_key_path=None if args.dkenv else keypath,
                                      branch_whitelist=branch_whitelist,
                                      build_tags=args.build_tags,
-                                     env_name=env_name)
+                                     env_name=args.dkenv if args.dkenv else env_name)
 
         if args.sync:
             built_docs = args.built_docs or find_sphinx_build_dir()
@@ -392,6 +395,9 @@ def configure(args, parser):
     if not args.force and on_travis():
         parser.error(red("doctr appears to be running on Travis. Use "
             "doctr configure --force to run anyway."))
+
+    if args.token and args.dkenv:
+        parser.error("The --token and --dkenv settings are incompatible.")
 
     if not args.authenticate:
         args.upload_key = False
@@ -494,11 +500,17 @@ def configure(args, parser):
         deploy_key_repo, env_name, keypath = get_deploy_key_repo(deploy_repo, args.key_path)
 
         private_ssh_key, public_ssh_key = generate_ssh_key()
-        key = encrypt_to_file(private_ssh_key, keypath + '.enc')
-        del private_ssh_key # Prevent accidental use below
+        if args.dkenv:
+            key = None  # don't need it on disk
+            encrypted_variable = None  # not applicable
+            private_ssh_key = private_ssh_key.decode('ASCII')  # Will print this later!
+        else:
+            key = encrypt_to_file(private_ssh_key, keypath + '.enc')
+            encrypted_variable = encrypt_variable(env_name.encode('utf-8') + b"=" + key,
+                                                  build_repo=build_repo, tld=tld,
+                                                  travis_token=travis_token, **login_kwargs)
+            private_ssh_key = None # Prevent accidental use below
         public_ssh_key = public_ssh_key.decode('ASCII')
-        encrypted_variable = encrypt_variable(env_name.encode('utf-8') + b"=" + key,
-                                              build_repo=build_repo, tld=tld, travis_token=travis_token, **login_kwargs)
 
         deploy_keys_url = 'https://github.com/{deploy_repo}/settings/keys'.format(deploy_repo=deploy_key_repo)
 
@@ -523,12 +535,12 @@ def configure(args, parser):
             """.format(ssh_key=public_ssh_key, deploy_keys_url=deploy_keys_url, N=N,
                        BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET)))
 
+        if not args.dkenv:
+            print(dedent("""\
+            {N}. {BOLD_MAGENTA}Add the file {keypath}.enc to be staged for commit:{RESET}
 
-        print(dedent("""\
-        {N}. {BOLD_MAGENTA}Add the file {keypath}.enc to be staged for commit:{RESET}
-
-            git add {keypath}.enc
-        """.format(keypath=keypath, N=N, BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET)))
+                git add {keypath}.enc
+            """.format(keypath=keypath, N=N, BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET)))
 
     options = '--built-docs ' + bold_black('<path/to/built/html/>')
     if args.key_path:
@@ -541,23 +553,38 @@ def configure(args, parser):
         options += ' --token'
         key_type = "personal access token"
 
+    if args.dkenv:
+        print(dedent("""\
+        {N}. {BOLD_MAGENTA}Add the following private deployment key to your TravisCI
+        repository settings as environment variable {env_name}:{RESET}
+
+        {private_ssh_key}
+
+        WARNING: Do not otherwise share this private key!
+        """.format(N=N, BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET,
+                   env_name=args.dkenv, private_ssh_key=private_ssh_key)))
+
     print(dedent("""\
     {N}. {BOLD_MAGENTA}Add these lines to your `.travis.yml` file:{RESET}
+    """.format(N=N, BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET)))
 
-        env:
-          global:
-            # Doctr {key_type} for {deploy_repo}
-            - secure: "{encrypted_variable}"
+    if not args.dkenv:
+        print(dedent("""\
+            env:
+              global:
+                # Doctr {key_type} for {deploy_repo}
+                - secure: "{encrypted_variable}"
+        """.format(key_type=key_type,
+                   encrypted_variable=encrypted_variable.decode('utf-8'))))
 
+    print(dedent("""\
         script:
           - set -e
           - {BOLD_BLACK}<Command to build your docs>{RESET}
           - pip install doctr
           - doctr deploy {options} {BOLD_BLACK}<target-directory>{RESET}
-    """.format(options=options, N=N, key_type=key_type,
-        encrypted_variable=encrypted_variable.decode('utf-8'),
-        deploy_repo=deploy_repo, BOLD_MAGENTA=BOLD_MAGENTA,
-        BOLD_BLACK=BOLD_BLACK, RESET=RESET)))
+    """.format(options=options, deploy_repo=deploy_repo,
+               BOLD_BLACK=BOLD_BLACK, RESET=RESET)))
 
     print(dedent("""\
     Replace the text in {BOLD_BLACK}<angle brackets>{RESET} with the relevant

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -165,11 +165,13 @@ def get_current_repo():
         'remote.origin.url']).decode('utf-8')
 
     # Travis uses the https clone url
-    try:
-        _, org, git_repo = remote_url.rsplit('.git', 1)[0].rsplit('/', 2)
-    except ValueError:
-        raise RuntimeError("Could not parse remote URL: %s" % remote_url)
-    return (org + '/' + git_repo)
+    # e.g. https://github.com/<owner>/<repo>.git
+    # If run outside Travis using --force, might have:
+    # e.g. git@github.com:<owner>/<repo>.git
+    if remote_url.endswith(".git"):
+        remote_url = remote_url[:-4]
+    _, owner, repo = remote_url.replace(":", "/").rsplit("/", 2)
+    return owner + '/' + repo
 
 def get_travis_branch():
     """Get the name of the branch that the PR is from.

--- a/doctr/travis.py
+++ b/doctr/travis.py
@@ -20,6 +20,14 @@ from cryptography.fernet import Fernet
 from .common import red, blue, yellow
 DOCTR_WORKING_BRANCH = '__doctr_working_branch'
 
+def write_private_key(filename, private_key_bytes):
+    """
+    Helper function to record (decrpted) private key to as file for ssh.
+    """
+    with open(filename, 'wb') as f:
+        f.write(filename)
+    os.chmod(filename, 0o600)
+
 def decrypt_file(file, key):
     """
     Decrypts the file ``file``.
@@ -41,10 +49,7 @@ def decrypt_file(file, key):
     with open(file, 'rb') as f:
         decrypted_file = fer.decrypt(f.read())
 
-    with open(file[:-4], 'wb') as f:
-        f.write(decrypted_file)
-
-    os.chmod(file[:-4], 0o600)
+    write_private_key(file[:-4], decrypted_file)
 
 def setup_deploy_key(keypath='github_deploy_key', key_ext='.enc', env_name='DOCTR_DEPLOY_ENCRYPTION_KEY'):
     """


### PR DESCRIPTION
Unfinished attempt to implement #348, adds a new command line option ``--dkenv`` short for deploy key in environment variable.

As far as I can tell, ``doctr configure --dbenv DOC_KEY ...`` works nicely. Building on the existing code this generates a key, sends the public key to the destination GitHub repository, and prints the private key to the terminal with instructions to add it to the source repository's TravisCI config.

However, something is breaking on the ``doctr deploy --dbenv DOC_KEY ...`` side, possibly in how I have been attempting to test is locally, and I don't understand enough of the design to immediately see where.

e.g. Something like this with ``--force`` and setting the ``$TRAVIS_REPO_SLUG`` variable to attempt to run locally:

```
$ TRAVIS_REPO_SLUG=owner/source doctr deploy ${TRAVIS_TAG:-dev} --dkenv DOC_KEY --build-tags --built-docs Doc/api/_build/html/ --deploy-repo owner/dest --force
```