### PR TITLE
DOC: warn about --force for dirty repos

### DIFF
--- a/doctr/__main__.py
+++ b/doctr/__main__.py
@@ -271,7 +271,9 @@ def deploy(args, parser):
 
     if not args.force and not on_travis():
         parser.error("doctr does not appear to be running on Travis. Use "
-                     "doctr deploy <target-dir> --force to run anyway.")
+                     "doctr deploy <target-dir> --force to run anyway.\n\n"
+                     "WARNING: this will remove any dirty files"
+                    )
 
     config = get_config()
 


### PR DESCRIPTION
**What does this PR implement?**
It warns about running `doctr deploy` with the `--force` flag and dirty files.

I made the mistake of doing this, and this warning would have prevented my mistake. I am submitting this PR to ask a question: how do I recover those dirty files untracked by Git? Or are they gone forever?