### PR TITLE
Update doctr configure to use the device authorization flow

### DIFF
--- a/doctr/common.py
+++ b/doctr/common.py
@@ -30,6 +30,9 @@ def bold_black(text):
 def bold_magenta(text):
     return "\033[1;35m%s\033[0m" % text
 
+def bold(text):
+    return "\033[1m%s\033[0m" % text
+
 # Use these when coloring individual parts of a larger string, e.g.,
 # "{BOLD_MAGENTA}Bright text{RESET} normal text".format(BOLD_MAGENTA=BOLD_MAGENTA, RESET=RESET)
 BOLD_BLACK = "\033[1;30m"


### PR DESCRIPTION
Authenticating with username and password no longer works, so this is required
to use doctr configure.

Fixes #369.

We should release this right away, as currently `doctr configure` doesn't work at all unless you use `--no-authenticate`.