### PR TITLE
Lint .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
+os: linux
+dist: xenial
 
-sudo: false
 env:
-  matrix:
+  jobs:
     - DOCS="true"
     - TESTS="true"
   global:
@@ -14,16 +15,12 @@ python:
   - 3.5
   - 3.6
 
-matrix:
+jobs:
   include:
     - python: 3.7
-      dist: xenial
-      sudo: true
       env:
         - DOCS="true"
     - python: 3.7
-      dist: xenial
-      sudo: true
       env:
         - TESTS="true"
 


### PR DESCRIPTION
Fixes warnings from https://config.travis-ci.com/explore

[warn] on jobs.include: deprecated key: "sudo" (The key `sudo` has no effect anymore.)
[warn] on jobs.include: deprecated key: "sudo" (The key `sudo` has no effect anymore.)
[warn] on root: deprecated key: "sudo" (The key `sudo` has no effect anymore.)
[info] on root: the key matrix is an alias for jobs, using jobs
[info] on env: the key matrix is an alias for jobs, using jobs
[info] on root: missing os, using the default "linux"